### PR TITLE
hide retrieval modes from API users

### DIFF
--- a/src/rank_llm/demo/rerank_dataset_with_prebuilt_index.py
+++ b/src/rank_llm/demo/rerank_dataset_with_prebuilt_index.py
@@ -16,7 +16,7 @@ print(retrieved_results)
 # TODO: add rerank instead of printing retrieved results
 
 # Users can specify other retrieval methods:
-retrieved_results = Retriever.from_dataset_with_prebuit_indexes(
+retrieved_results = Retriever.from_dataset_with_prebuit_index(
     dataset_name, RetrievalMethod.SPLADE_P_P_ENSEMBLE_DISTIL
 )
 print(retrieved_results)

--- a/src/rank_llm/demo/rerank_dataset_with_prebuilt_index.py
+++ b/src/rank_llm/demo/rerank_dataset_with_prebuilt_index.py
@@ -1,0 +1,23 @@
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
+
+from rank_llm.retrieve.retriever import Retriever
+from rank_llm.retrieve.pyserini_retriever import RetrievalMethod
+
+# By default uses BM25 for retrieval
+dataset_name = "dl19"
+retrieved_results = Retriever.from_dataset_with_prebuit_index(dataset_name)
+print(retrieved_results)
+# TODO: add rerank instead of printing retrieved results
+
+# Users can specify other retrieval methods:
+retrieved_results = Retriever.from_dataset_with_prebuit_indexes(
+    dataset_name, RetrievalMethod.SPLADE_P_P_ENSEMBLE_DISTIL
+)
+print(retrieved_results)
+# TODO: add rerank instead of printing retrieved results

--- a/src/rank_llm/demo/rerank_inline_docs.py
+++ b/src/rank_llm/demo/rerank_inline_docs.py
@@ -6,9 +6,7 @@ parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
-from rank_llm.retrieve_and_rerank import retrieve_and_rerank
-from rank_llm.retrieve.retriever import RetrievalMode
-from rank_llm.retrieve.pyserini_retriever import RetrievalMethod
+from rank_llm.retrieve.retriever import Retriever
 
 query = "What is the capital of the United States?"
 docs = [
@@ -18,14 +16,6 @@ docs = [
     "Capital punishment (the death penalty) has existed in the United States since before the United States was a country. As of 2017, capital punishment is legal in 30 of the 50 states.",
 ]
 
-results = retrieve_and_rerank(
-    model_path="castorini/rank_zephyr_7b_v1_full",
-    dataset=docs,
-    retrieval_mode=RetrievalMode.QUERY_AND_DOCUMENTS,
-    retrieval_method=RetrievalMethod.UNSPECIFIED,
-    top_k_candidates=len(docs),
-    print_prompts_responses=True,
-    query=query,
-    variable_passages=True,
-    system_message="You are RankLLM, an intelligent assistant that can rank passages based on their relevancy to the query.",
-)
+retrieved_results = Retriever.from_inline_documents(query, documents=docs)
+print(retrieved_results)
+# TODO: add rerank instead of printing retrieved results

--- a/src/rank_llm/demo/rerank_inline_hits.py
+++ b/src/rank_llm/demo/rerank_inline_hits.py
@@ -6,9 +6,7 @@ parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
-from rank_llm.retrieve_and_rerank import retrieve_and_rerank
-from rank_llm.retrieve.retriever import RetrievalMode
-from rank_llm.retrieve.pyserini_retriever import RetrievalMethod
+from rank_llm.retrieve.retriever import Retriever
 
 query = "how long is life cycle of flea"
 hits = [
@@ -70,14 +68,6 @@ hits = [
     },
 ]
 
-results = retrieve_and_rerank(
-    model_path="castorini/rank_zephyr_7b_v1_full",
-    dataset=hits,
-    retrieval_mode=RetrievalMode.QUERY_AND_HITS,
-    retrieval_method=RetrievalMethod.UNSPECIFIED,
-    top_k_candidates=len(hits),
-    print_prompts_responses=True,
-    query=query,
-    variable_passages=True,
-    system_message="You are RankLLM, an intelligent assistant that can rank passages based on their relevancy to the query.",
-)
+retrieved_results = Retriever.from_inline_hits(query=query, hits=hits)
+print(retrieved_results)
+# TODO: add rerank instead of printing retrieved results

--- a/src/rank_llm/demo/rerank_stored_retrieved_results.py
+++ b/src/rank_llm/demo/rerank_stored_retrieved_results.py
@@ -1,0 +1,14 @@
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
+
+from rank_llm.retrieve.retriever import Retriever
+
+file_name = "retrieve_results/BM25/retrieve_results_dl19.json"
+retrieved_results = Retriever.from_saved_results(file_name)
+print(retrieved_results)
+# TODO: add rerank instead of printing retrieved results

--- a/src/rank_llm/retrieve/pyserini_retriever.py
+++ b/src/rank_llm/retrieve/pyserini_retriever.py
@@ -191,6 +191,7 @@ class PyseriniRetriever:
                         f.write(
                             f"{hit['qid']} Q0 {hit['docid']} {hit['rank']} {hit['score']} rank\n"
                         )
+        return results
 
 
 def evaluate_retrievals() -> None:

--- a/src/rank_llm/retrieve/retriever.py
+++ b/src/rank_llm/retrieve/retriever.py
@@ -17,41 +17,100 @@ class RetrievalMode(Enum):
 
 
 class Retriever:
-    def __init__(self, retrieval_mode: RetrievalMode) -> None:
-        self._retrieval_mode = retrieval_mode
-
-    def retrieve(
+    def __init__(
         self,
+        retrieval_mode: RetrievalMode,
         dataset: Union[str, List[str], List[Dict[str, Any]]],
         retrieval_method: RetrievalMethod = RetrievalMethod.UNSPECIFIED,
-        query: str = "",
-    ) -> Union[None, List[Dict[str, Any]]]:
-        """
-        Retriever supports three modes:
+        query: str = None,
+    ) -> None:
+        self._retrieval_mode = retrieval_mode
+        self._dataset = dataset
+        self._retrieval_method = retrieval_method
+        self._query = query
 
-        - DATASET: args = (dataset, retrieval_method)
-        - QUERY_AND_DOCUMENTS: args = (dataset, query)
-        - QUERY_AND_HITS: args = (dataset, query)
-        """
+    @staticmethod
+    def validate_result(result: Dict[str, Any]):
+        if not isinstance(result, dict):
+            raise ValueError(
+                f"Invalid result format: Expected a dictionary, got {type(result)}"
+            )
+        if "query" not in result.keys():
+            raise ValueError(f"Invalid format: missing `query` key")
+        if "hits" not in result.keys():
+            raise ValueError(f"Invalid format: missing `hits` key")
+        for hit in result["hits"]:
+            if not isinstance(hit, Dict):
+                raise ValueError(
+                    f"Invalid hits format: Expected a list of Dicts where each Dict represents a hit."
+                )
+            if "content" not in hit.keys():
+                raise ValueError((f"Invalid format: Missing `content` key in hit"))
+
+    @staticmethod
+    def from_inline_documents(query: str, documents: List[str]):
+        if not query or query == "":
+            raise "Please provide a query string."
+        if not documents:
+            raise "Please provide a non-empty list of documents."
+        retriever = Retriever(
+            RetrievalMode.QUERY_AND_DOCUMENTS, dataset=documents, query=query
+        )
+        return retriever.retrieve()
+
+    @staticmethod
+    def from_inline_hits(query: str, hits: List[Dict[str, Any]]):
+        if not query or query == "":
+            raise "Please provide a query string."
+        if not hits:
+            raise "Please provide a non-empty list of hits."
+        Retriever.validate_result({"query": query, "hits": hits})
+        retriever = Retriever(RetrievalMode.QUERY_AND_HITS, dataset=hits, query=query)
+        return retriever.retrieve()
+
+    @staticmethod
+    def from_dataset_with_prebuit_index(
+        dataset_name: str, retrieval_method: RetrievalMethod = RetrievalMethod.BM25
+    ):
+        if not dataset_name:
+            raise "Please provide name of the dataset."
+        if not isinstance(dataset_name, str):
+            raise ValueError(
+                f"Invalid dataset format: {dataset_name}. Expected a string representing name of the dataset."
+            )
+        if not retrieval_method:
+            raise "Please provide a retrieval method."
+        if retrieval_method == RetrievalMethod.UNSPECIFIED:
+            raise ValueError(
+                f"Invalid retrieval method: {retrieval_method}. Please provide a specific retrieval method."
+            )
+        retriever = Retriever(
+            RetrievalMode.DATASET,
+            dataset=dataset_name,
+            retrieval_method=retrieval_method,
+        )
+        return retriever.retrieve()
+
+    @staticmethod
+    def from_saved_results(file_name: str):
+        with open(file_name, "r") as f:
+            retrieved_results = json.load(f)
+        if not isinstance(retrieved_results, list):
+            raise ValueError(
+                f"Invalid retrieval format: Expected a list of dictionaries, got {type(retrieved_results)}"
+            )
+        for result in retrieved_results:
+            Retriever.validate_result(result)
+        return retrieved_results
+
+    def retrieve(self) -> List[Dict[str, Any]]:
         if self._retrieval_mode == RetrievalMode.DATASET:
-            if not dataset:
-                raise "Please provide name of the dataset."
-            if not isinstance(dataset, str):
-                raise ValueError(
-                    f"Invalid dataset format: {dataset}. Expected a string representing name of the dataset."
-                )
-            if not retrieval_method:
-                raise "Please provide a retrieval method."
-            if retrieval_method == RetrievalMethod.UNSPECIFIED:
-                raise ValueError(
-                    f"Invalid retrieval method: {retrieval_method}. Please provide a specific retrieval method."
-                )
             candidates_file = Path(
-                f"retrieve_results/{retrieval_method.name}/retrieve_results_{dataset}.json"
+                f"retrieve_results/{self._retrieval_method.name}/retrieve_results_{self._dataset}.json"
             )
             if not candidates_file.is_file():
-                print(f"Retrieving with dataset {dataset}")
-                retriever = PyseriniRetriever(dataset, retrieval_method)
+                print(f"Retrieving with dataset {self._dataset}")
+                retriever = PyseriniRetriever(self._dataset, self._retrieval_method)
                 # Always retrieve top 100 so that results are reusable for all top_k_candidates values.
                 retriever.retrieve_and_store(k=100)
             else:
@@ -62,39 +121,28 @@ class Retriever:
             return retrieved_results
 
         elif self._retrieval_mode == RetrievalMode.QUERY_AND_DOCUMENTS:
-            if not dataset:
-                raise "Please provide a non-empty list of documents."
-            if not query or query == "":
-                raise "Please provide a query string."
             document_hits = []
-            for document in dataset:
+            for i, document in enumerate(self._dataset):
                 if not isinstance(document, str):
                     raise ValueError(
-                        f"Invalid dataset format: {dataset}. Expected a list of strings where each string represents a document."
+                        f"Invalid dataset format: {self._dataset}. Expected a list of strings where each string represents a document."
                     )
-                document_hits.append({"content": document})
+                document_hits.append(
+                    {"content": document, "qid": 1, "docid": i + 1, "rank": i + 1}
+                )
             retrieved_result = [
                 {
-                    "query": query,
+                    "query": self._query,
                     "hits": document_hits,
                 }
             ]
             return retrieved_result
 
         elif self._retrieval_mode == RetrievalMode.QUERY_AND_HITS:
-            if not dataset:
-                raise "Please provide a non-empty list of hits."
-            for hit in dataset:
-                if not isinstance(hit, Dict):
-                    raise ValueError(
-                        f"Invalid dataset format: {dataset}. Expected a list of Dicts where each Dict represents a hit."
-                    )
-            if not query or query == "":
-                raise "Please provide a query string."
             retrieved_result = [
                 {
-                    "query": query,
-                    "hits": dataset,
+                    "query": self._query,
+                    "hits": self._dataset,
                 }
             ]
             return retrieved_result

--- a/src/rank_llm/retrieve_and_rerank.py
+++ b/src/rank_llm/retrieve_and_rerank.py
@@ -83,15 +83,17 @@ def retrieve_and_rerank(
     # Retrieve
     print("Retrieving:")
     if retrieval_mode == RetrievalMode.DATASET:
-        retriever = Retriever(RetrievalMode.DATASET)
-        retrieved_results = retriever.retrieve(dataset, retrieval_method=retrieval_method)
+        retrieved_results = Retriever.from_dataset_with_prebuit_index(
+            dataset_name=dataset, retrieval_method=retrieval_method
+        )
     elif retrieval_mode == RetrievalMode.QUERY_AND_DOCUMENTS:
-        retriever = Retriever(RetrievalMode.QUERY_AND_DOCUMENTS)
-        retrieved_results = retriever.retrieve(dataset, query=query)
+        retrieved_results = Retriever.from_inline_documents(
+            query=query, documents=dataset
+        )
     elif retrieval_mode == RetrievalMode.QUERY_AND_HITS:
-        retriever = Retriever(RetrievalMode.QUERY_AND_HITS)
-        retrieved_results = retriever.retrieve(dataset, query=query)
-
+        retrieved_results = Retriever.from_inline_hits(query=query, hits=dataset)
+    elif retrieval_mode == RetrievalMode.SAVED_FILE:
+        retrieved_results = Retriever.from_saved_results(file_name=dataset)
     else:
         raise ValueError(f"Invalid retrieval mode: {retrieval_mode}")
     print("Reranking:")

--- a/src/rank_llm/scripts/run_rank_llm.py
+++ b/src/rank_llm/scripts/run_rank_llm.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
         "--dataset",
         type=str,
         required=True,
-        help=f"dataset name, must be in {TOPICS.keys()}",
+        help=f"Should be one of 1- dataset name, must be in {TOPICS.keys()},  2- a list of inline documents  3- a list of inline hits 4- filename containing retrieved results",
     )
     parser.add_argument(
         "--num_gpus", type=int, default=1, help="the number of GPUs to use"


### PR DESCRIPTION
This cl:

- Adds static methods to create retriever instances from different inputs. This change hides the internal retrieval mode from the end user.
- Fixes the demos accordingly, with TODOs left for the reranking part
- Adds support for reading stored retrieved results from file
- In `inline_documents` mode populate more fields in the retrieved_results

Creating Results class, and abstracting reranker details of agent creation, etc will come in follow up cls.
