### PR TITLE
Sliding Window logic fix and additional token length in larger candidates

### DIFF
--- a/src/rank_llm/rerank/rank_gpt.py
+++ b/src/rank_llm/rerank/rank_gpt.py
@@ -151,7 +151,7 @@ class SafeOpenai(RankLLM):
         query = retrieved_result["query"]
         num = len(retrieved_result["hits"][rank_start:rank_end])
 
-        max_length = 300
+        max_length = 300 * (20 / (rank_end - rank_start))
         while True:
             messages = self._get_prefix_for_rank_gpt_prompt(query, num)
             rank = 0
@@ -191,7 +191,7 @@ class SafeOpenai(RankLLM):
     ) -> Tuple[List[Dict[str, str]], int]:
         query = retrieved_result["query"]
         num = len(retrieved_result["hits"][rank_start:rank_end])
-        max_length = 300
+        max_length = 300 * (20 / (rank_end - rank_start))
         psg_ids = []
         while True:
             message = "Sort the list PASSAGES by how good each text answers the QUESTION (in descending order of relevancy).\n"

--- a/src/rank_llm/rerank/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/rank_listwise_os_llm.py
@@ -72,8 +72,9 @@ class RankListwiseOSLLM(RankLLM):
     def num_output_tokens(self, current_window_size: Optional[int] = None) -> int:
         if current_window_size is None:
             current_window_size = self._window_size
-        _output_token_estimate = None
-        if self._output_token_estimate is None or self._window_size != current_window_size:
+        if self._output_token_estimate and self._window_size == current_window_size:
+            return self._output_token_estimate
+        else:
             _output_token_estimate = (
                 len(
                     self._tokenizer.encode(
@@ -82,9 +83,9 @@ class RankListwiseOSLLM(RankLLM):
                 )
                 - 1
             )
-        if self._output_token_estimate is None:
-            self._output_token_estimate = _output_token_estimate
-        return _output_token_estimate if _output_token_estimate else self._output_token_estimate
+            if self._output_token_estimate is None:
+                self._output_token_estimate = _output_token_estimate
+            return _output_token_estimate
 
     def _add_prefix_prompt(self, query: str, num: int) -> str:
         return f"I will provide you with {num} passages, each indicated by a numerical identifier []. Rank the passages based on their relevance to the search query: {query}.\n"

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -101,6 +101,8 @@ class RankLLM(ABC):
         start_pos = rank_end - window_size
         prompts = []
         permutations = []
+        # end_pos > rank_start ensures that the list is non-empty while allowing last window to be smaller than window_size
+        # start_pos + step != rank_start prevents processing of redundant windows (e.g. 0-20, followed by 0-10)
         while end_pos > rank_start and start_pos + step != rank_start:
             start_pos = max(start_pos, rank_start)
             (

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -101,7 +101,7 @@ class RankLLM(ABC):
         start_pos = rank_end - window_size
         prompts = []
         permutations = []
-        while start_pos >= rank_start:
+        while end_pos > rank_start and start_pos + step != rank_start:
             start_pos = max(start_pos, rank_start)
             (
                 rerank_result,


### PR DESCRIPTION
I was trying to stress test and our sliding window logic seemed to be failing in irregular windows that might not align perfectly with the candidate set size (which is a majority of cases, besides our settings like (20, 10) on candidates of 20/100, etc.).

This should fix it.

Additionally, some non-breaking changes (for our (20, 10) experiments) when we are dealing with smaller windows (you don't need to fix a 300 token limit).