### PR TITLE
Create results class

### DIFF
--- a/src/rank_llm/rerank/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/rank_listwise_os_llm.py
@@ -140,7 +140,11 @@ class RankListwiseOSLLM(RankLLM):
             else:
                 max_length -= max(
                     1,
-                    (num_tokens - self.max_tokens() + self.num_output_tokens(rank_end - rank_start))
+                    (
+                        num_tokens
+                        - self.max_tokens()
+                        + self.num_output_tokens(rank_end - rank_start)
+                    )
                     // ((rank_end - rank_start) * 4),
                 )
         return prompt, self.get_num_tokens(prompt)

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 class RankingExecInfo:
     def __init__(
         self, prompt, response: str, input_token_count: int, output_token_count: int
-    ) -> None:
+    ):
         self.prompt = prompt
         self.response = response
         self.input_token_count = input_token_count
@@ -22,6 +22,9 @@ class Result:
         self.query = query
         self.hits = hits
         self.ranking_exec_summary = ranking_exec_summary
+
+    def __repr__(self):
+        return str(self.__dict__)
 
 
 class ResultsWriter:
@@ -45,12 +48,12 @@ class ResultsWriter:
         for result in self._results:
             results.append({"query": result.query, "hits": result.hits})
         with open(filename, "a" if self._append else "w") as f:
-            json.dump(result, f, indent=2)
+            json.dump(results, f, indent=2)
 
     def write_in_trec_eval_format(self, filename: str):
         with open(filename, "a" if self._append else "w") as f:
             for result in self._results:
-                for hit in result["hits"]:
+                for hit in result.hits:
                     f.write(
                         f"{hit['qid']} Q0 {hit['docid']} {hit['rank']} {hit['score']} rank\n"
                     )

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -1,0 +1,56 @@
+import json
+from typing import List, Dict, Any
+
+
+class RankingExecInfo:
+    def __init__(
+        self, prompt, response: str, input_token_count: int, output_token_count: int
+    ) -> None:
+        self.prompt = prompt
+        self.response = response
+        self.input_token_count = input_token_count
+        self.output_token_count = output_token_count
+
+
+class Result:
+    def __init__(
+        self,
+        query: str,
+        hits: List[Dict[str, Any]],
+        ranking_exec_summary: List[RankingExecInfo] = None,
+    ):
+        self.query = query
+        self.hits = hits
+        self.ranking_exec_summary = ranking_exec_summary
+
+
+class ResultsWriter:
+    def __init__(self, results: List[Result], append: bool = False):
+        self._results = results
+        self._append = append
+
+    def write_ranking_exec_summary(self, filename: str):
+        exec_summary = {}
+        for result in self._results:
+            key = result.query
+            values = []
+            for info in result.ranking_exec_summary:
+                values.append(info.__dict__)
+            exec_summary[key] = values
+        with open(filename, "a" if self._append else "w") as f:
+            json.dump(exec_summary, f, indent=2)
+
+    def write_in_json_format(self, filename: str):
+        results = []
+        for result in self._results:
+            results.append({"query": result.query, "hits": result.hits})
+        with open(filename, "a" if self._append else "w") as f:
+            json.dump(result, f, indent=2)
+
+    def write_in_trec_eval_format(self, filename: str):
+        with open(filename, "a" if self._append else "w") as f:
+            for result in self._results:
+                for hit in result["hits"]:
+                    f.write(
+                        f"{hit['qid']} Q0 {hit['docid']} {hit['rank']} {hit['score']} rank\n"
+                    )

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -33,13 +33,12 @@ class ResultsWriter:
         self._append = append
 
     def write_ranking_exec_summary(self, filename: str):
-        exec_summary = {}
+        exec_summary = []
         for result in self._results:
-            key = result.query
             values = []
             for info in result.ranking_exec_summary:
                 values.append(info.__dict__)
-            exec_summary[key] = values
+            exec_summary.append({"query": result.query, "ranking_exec_summary": values})
         with open(filename, "a" if self._append else "w") as f:
             json.dump(exec_summary, f, indent=2)
 

--- a/src/rank_llm/retrieve/retriever.py
+++ b/src/rank_llm/retrieve/retriever.py
@@ -5,6 +5,7 @@ from typing import List, Union, Dict, Any
 
 from rank_llm.retrieve.pyserini_retriever import PyseriniRetriever
 from rank_llm.retrieve.pyserini_retriever import RetrievalMethod
+from rank_llm.result import Result
 
 
 class RetrievalMode(Enum):
@@ -110,22 +111,14 @@ class Retriever:
                 document_hits.append(
                     {"content": document, "qid": 1, "docid": i + 1, "rank": i + 1}
                 )
-            retrieved_results = [
-                {
-                    "query": self._query,
-                    "hits": document_hits,
-                }
-            ]
+            retrieved_results = [Result(self._query, document_hits)]
 
         elif self._retrieval_mode == RetrievalMode.QUERY_AND_HITS:
-            retrieved_results = [
-                {
-                    "query": self._query,
-                    "hits": self._dataset,
-                }
-            ]
+            retrieved_results = [Result(self._query, self._dataset)]
         elif self._retrieval_mode == RetrievalMode.SAVED_FILE:
-            retrieved_results = self._dataset
+            retrieved_results = [
+                Result(query=r["query"], hits=r["hits"]) for r in self._dataset
+            ]
         else:
             raise ValueError(f"Invalid retrieval mode: {self._retrieval_mode}")
         for result in retrieved_results:

--- a/src/rank_llm/retrieve/retriever.py
+++ b/src/rank_llm/retrieve/retriever.py
@@ -48,7 +48,6 @@ class Retriever:
             raise "Please provide a query string."
         if not hits:
             raise "Please provide a non-empty list of hits."
-        Retriever.validate_result({"query": query, "hits": hits})
         retriever = Retriever(RetrievalMode.QUERY_AND_HITS, dataset=hits, query=query)
         return retriever.retrieve()
 
@@ -99,7 +98,10 @@ class Retriever:
             else:
                 print("Reusing existing retrieved results.")
                 with open(candidates_file, "r") as f:
-                    retrieved_results = json.load(f)
+                    loaded_results = json.load(f)
+                retrieved_results = [
+                    Result(r["query"], r["hits"]) for r in loaded_results
+                ]
 
         elif self._retrieval_mode == RetrievalMode.QUERY_AND_DOCUMENTS:
             document_hits = []
@@ -125,16 +127,16 @@ class Retriever:
             self._validate_result(result)
         return retrieved_results
 
-    def _validate_result(self, result: Dict[str, Any]):
-        if not isinstance(result, dict):
+    def _validate_result(self, result: Result):
+        if not isinstance(result, Result):
             raise ValueError(
-                f"Invalid result format: Expected a dictionary, got {type(result)}"
+                f"Invalid result format: Expected type `Result`, got {type(result)}"
             )
-        if "query" not in result.keys():
-            raise ValueError(f"Invalid format: missing `query` key")
-        if "hits" not in result.keys():
-            raise ValueError(f"Invalid format: missing `hits` key")
-        for hit in result["hits"]:
+        if not result.query:
+            raise ValueError(f"Invalid format: missing `query`")
+        if not result.hits:
+            raise ValueError(f"Invalid format: missing `hits`")
+        for hit in result.hits:
             if not isinstance(hit, Dict):
                 raise ValueError(
                     f"Invalid hits format: Expected a list of Dicts where each Dict represents a hit."


### PR DESCRIPTION
This cl:
1- creates a `Result` class and integrates it to retriever. In all retrieval modes the retriever now returns a list[Result] rather than list[dict]. 
2- creates a helper 'ResultsWriter` class to take care of writing results to files.

Changing the reranker to read from this new result type will be submitted in a follow up cl.

TESTED=ran all demos of different retrieval modes.