### PR TITLE
Integrate result class in reranker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ prompts_and_responses/
 rerank_results/
 token_counts/
 retrieve_results/
+ranking_execution_summary/
 repro/

--- a/src/rank_llm/evaluation/trec_eval.py
+++ b/src/rank_llm/evaluation/trec_eval.py
@@ -26,8 +26,8 @@ class EvalFunction:
     @staticmethod
     def trunc(qrels, run):
         qrels = get_qrels_file(qrels)
-        run = pd.read_csv(run, delim_whitespace=True, header=None)
-        qrels = pd.read_csv(qrels, delim_whitespace=True, header=None)
+        run = pd.read_csv(run, sep='\s+', header=None)
+        qrels = pd.read_csv(qrels, sep='\s+', header=None)
         run[0] = run[0].astype(str)
         qrels[0] = qrels[0].astype(str)
 
@@ -76,7 +76,7 @@ class EvalFunction:
                     print("msmarco run detected. Converting to trec...")
                     run = pd.read_csv(
                         args[-1],
-                        delim_whitespace=True,
+                        sep='\s+',
                         header=None,
                         names=["query_id", "doc_id", "rank"],
                     )
@@ -86,8 +86,8 @@ class EvalFunction:
                     run.to_csv(temp_file, sep="\t", header=None, index=None)
                     args[-1] = temp_file
 
-            run = pd.read_csv(args[-1], delim_whitespace=True, header=None)
-            qrels = pd.read_csv(args[-2], delim_whitespace=True, header=None)
+            run = pd.read_csv(args[-1], sep='\s+', header=None)
+            qrels = pd.read_csv(args[-2], sep='\s+', header=None)
 
             # cast doc_id column as string
             run[0] = run[0].astype(str)
@@ -148,12 +148,16 @@ def main(args):
             for retrieval_method in RetrievalMethod:
                 if retrieval_method == RetrievalMethod.UNSPECIFIED:
                     continue
+                directory = f"rerank_results/{retrieval_method.name}"
+                if not os.path.isdir(directory):
+                    continue
                 for top_k_canidadates in [20, 100]:
-                    directory = f"rerank_results/{retrieval_method.name}"
                     for filename in os.listdir(directory):
                         if not filename.startswith(
                             f"{model}_{context_size}_{top_k_canidadates}_{prompt_mode}_{dataset}"
                         ):
+                            continue
+                        if filename.endswith(".json"):
                             continue
                         f = os.path.join(directory, filename)
                         # checking if it is a file

--- a/src/rank_llm/evaluation/trec_eval.py
+++ b/src/rank_llm/evaluation/trec_eval.py
@@ -26,8 +26,8 @@ class EvalFunction:
     @staticmethod
     def trunc(qrels, run):
         qrels = get_qrels_file(qrels)
-        run = pd.read_csv(run, sep='\s+', header=None)
-        qrels = pd.read_csv(qrels, sep='\s+', header=None)
+        run = pd.read_csv(run, sep="\s+", header=None)
+        qrels = pd.read_csv(qrels, sep="\s+", header=None)
         run[0] = run[0].astype(str)
         qrels[0] = qrels[0].astype(str)
 
@@ -76,7 +76,7 @@ class EvalFunction:
                     print("msmarco run detected. Converting to trec...")
                     run = pd.read_csv(
                         args[-1],
-                        sep='\s+',
+                        sep="\s+",
                         header=None,
                         names=["query_id", "doc_id", "rank"],
                     )
@@ -86,8 +86,8 @@ class EvalFunction:
                     run.to_csv(temp_file, sep="\t", header=None, index=None)
                     args[-1] = temp_file
 
-            run = pd.read_csv(args[-1], sep='\s+', header=None)
-            qrels = pd.read_csv(args[-2], sep='\s+', header=None)
+            run = pd.read_csv(args[-1], sep="\s+", header=None)
+            qrels = pd.read_csv(args[-2], sep="\s+", header=None)
 
             # cast doc_id column as string
             run[0] = run[0].astype(str)

--- a/src/rank_llm/rerank/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/rank_listwise_os_llm.py
@@ -9,6 +9,7 @@ import torch
 from transformers.generation import GenerationConfig
 
 from rank_llm.rerank.rankllm import RankLLM, PromptMode
+from rank_llm.result import Result
 
 
 def replace_number(s):
@@ -105,10 +106,10 @@ class RankListwiseOSLLM(RankLLM):
         return conv
 
     def create_prompt(
-        self, retrieved_result: Dict[str, Any], rank_start: int, rank_end: int
+        self, result: Result, rank_start: int, rank_end: int
     ) -> Tuple[str, int]:
-        query = retrieved_result["query"]
-        num = len(retrieved_result["hits"][rank_start:rank_end])
+        query = result.query
+        num = len(result.hits[rank_start:rank_end])
         max_length = 300 * (20 / (rank_end - rank_start))
         while True:
             conv = get_conversation_template(self._model)
@@ -118,7 +119,7 @@ class RankListwiseOSLLM(RankLLM):
             prefix = self._add_prefix_prompt(query, num)
             rank = 0
             input_context = f"{prefix}\n"
-            for hit in retrieved_result["hits"][rank_start:rank_end]:
+            for hit in result.hits[rank_start:rank_end]:
                 rank += 1
                 content = hit["content"]
                 content = content.replace("Title: Content: ", "")

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -71,13 +71,13 @@ class RankLLM(ABC):
         )
         if logging:
             print(f"output: {permutation}")
-        ranking_exec_info = RankingExecInfo(prompt, permutation, in_token_count, out_token_count)
+        ranking_exec_info = RankingExecInfo(
+            prompt, permutation, in_token_count, out_token_count
+        )
         if result.ranking_exec_summary == None:
             result.ranking_exec_summary = []
         result.ranking_exec_summary.append(ranking_exec_info)
-        result = self.receive_permutation(
-            result, permutation, rank_start, rank_end
-        )
+        result = self.receive_permutation(result, permutation, rank_start, rank_end)
         return result
 
     def sliding_windows(
@@ -107,7 +107,9 @@ class RankLLM(ABC):
         # start_pos + step != rank_start prevents processing of redundant windows (e.g. 0-20, followed by 0-10)
         while end_pos > rank_start and start_pos + step != rank_start:
             start_pos = max(start_pos, rank_start)
-            rerank_result = self.permutation_pipeline(rerank_result, start_pos, end_pos, logging)
+            rerank_result = self.permutation_pipeline(
+                rerank_result, start_pos, end_pos, logging
+            )
             end_pos = end_pos - step
             start_pos = start_pos - step
         return rerank_result

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -6,6 +6,7 @@ from typing import List, Union, Dict, Any
 from tqdm import tqdm
 
 from rank_llm.rerank.rankllm import RankLLM
+from rank_llm.result import Result, ResultsWriter
 
 
 class Reranker:
@@ -13,21 +14,10 @@ class Reranker:
         self._agent = agent
         self._top_k_candidates = top_k_candidates
 
-    def rerank(self, retrieved_results: List[Dict[str, Any]], **kwargs):
+    def rerank(self, retrieved_results: List[Result], **kwargs):
         rerank_results = []
-        input_token_counts = []
-        output_token_counts = []
-        aggregated_prompts = []
-        aggregated_responses = []
-
         for result in tqdm(retrieved_results):
-            (
-                rerank_result,
-                in_token_count,
-                out_token_count,
-                prompts,
-                responses,
-            ) = self._agent.sliding_windows(
+            rerank_result = self._agent.sliding_windows(
                 result,
                 rank_start=0,
                 rank_end=kwargs["rank_end"],
@@ -37,43 +27,17 @@ class Reranker:
                 logging=kwargs["logging"],
             )
             rerank_results.append(rerank_result)
-            input_token_counts.append(in_token_count)
-            output_token_counts.append(out_token_count)
-            aggregated_prompts.extend(prompts)
-            aggregated_responses.extend(responses)
-
-        # print(f"rerank_results={rerank_results}")
-        print(f"input_tokens_counts={input_token_counts}")
-        print(f"total input token count={sum(input_token_counts)}")
-        print(f"output_token_counts={output_token_counts}")
-        print(f"total output token count={sum(output_token_counts)}")
-
-        return (
-            rerank_results,
-            input_token_counts,
-            output_token_counts,
-            aggregated_prompts,
-            aggregated_responses,
-        )
+        return rerank_results
 
     def write_rerank_results(
         self,
         retrieval_method_name: str,
-        rerank_results: List[Dict[str, Any]],
-        input_token_counts: List[int],
-        output_token_counts: List[int],
-        # List[str] for Vicuna, List[List[Dict[str, str]]] for gpt models.
-        prompts: Union[List[str], List[List[Dict[str, str]]]],
-        responses: List[str],
+        results: List[Result],
         shuffle_candidates: bool = False,
         pass_ct: int = None,
         window_size: int = None,
         dataset_name: str = None,
     ) -> str:
-        # write rerank results
-        Path(f"rerank_results/{retrieval_method_name}/").mkdir(
-            parents=True, exist_ok=True
-        )
         _modelname = self._agent._model.split("/")[-1]
         if _modelname.startswith("checkpoint"):
             _modelname = self._agent._model.split("/")[-2] + "_" + _modelname
@@ -91,37 +55,17 @@ class Reranker:
             name += f"_window_{window_size}"
         if pass_ct is not None:
             name += f"_pass_{pass_ct}"
+        # write rerank results
+        writer = ResultsWriter(results)
+        Path(f"rerank_results/{retrieval_method_name}/").mkdir(
+            parents=True, exist_ok=True
+        )
         result_file_name = f"rerank_results/{retrieval_method_name}/{name}.txt"
-        with open(result_file_name, "w") as f:
-            for i in range(len(rerank_results)):
-                rank = 1
-                hits = rerank_results[i]["hits"]
-                for hit in hits:
-                    f.write(
-                        f"{hit['qid']} Q0 {hit['docid']} {rank} {hit['score']} rank\n"
-                    )
-                    rank += 1
-        # Write token counts
-        Path(f"token_counts/{retrieval_method_name}/").mkdir(
+        writer.write_in_trec_eval_format(result_file_name)
+        writer.write_in_json_format(f"rerank_results/{retrieval_method_name}/{name}.json")
+        # Write ranking execution summary
+        Path(f"ranking_execution_summary/{retrieval_method_name}/").mkdir(
             parents=True, exist_ok=True
         )
-        count_file_name = f"token_counts/{retrieval_method_name}/{name}.txt"
-        counts = {}
-        for i, (in_count, out_count) in enumerate(
-            zip(input_token_counts, output_token_counts)
-        ):
-            counts[rerank_results[i]["query"]] = (in_count, out_count)
-        with open(count_file_name, "w") as f:
-            json.dump(counts, f, indent=4)
-        # Write prompts and responses
-        Path(f"prompts_and_responses/{retrieval_method_name}/").mkdir(
-            parents=True, exist_ok=True
-        )
-        with open(
-            f"prompts_and_responses/{retrieval_method_name}/{name}.json",
-            "w",
-        ) as f:
-            for p, r in zip(prompts, responses):
-                json.dump({"prompt": p, "response": r}, f)
-                f.write("\n")
+        writer.write_ranking_exec_summary(f"ranking_execution_summary/{retrieval_method_name}/{name}.txt")
         return result_file_name

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -62,10 +62,14 @@ class Reranker:
         )
         result_file_name = f"rerank_results/{retrieval_method_name}/{name}.txt"
         writer.write_in_trec_eval_format(result_file_name)
-        writer.write_in_json_format(f"rerank_results/{retrieval_method_name}/{name}.json")
+        writer.write_in_json_format(
+            f"rerank_results/{retrieval_method_name}/{name}.json"
+        )
         # Write ranking execution summary
         Path(f"ranking_execution_summary/{retrieval_method_name}/").mkdir(
             parents=True, exist_ok=True
         )
-        writer.write_ranking_exec_summary(f"ranking_execution_summary/{retrieval_method_name}/{name}.txt")
+        writer.write_ranking_exec_summary(
+            f"ranking_execution_summary/{retrieval_method_name}/{name}.txt"
+        )
         return result_file_name

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -70,6 +70,6 @@ class Reranker:
             parents=True, exist_ok=True
         )
         writer.write_ranking_exec_summary(
-            f"ranking_execution_summary/{retrieval_method_name}/{name}.txt"
+            f"ranking_execution_summary/{retrieval_method_name}/{name}.json"
         )
         return result_file_name

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -28,10 +28,6 @@ class Result:
 
     def __repr__(self):
         return str(self.__dict__)
-<<<<<<< HEAD
-=======
-
->>>>>>> integrated result into pyserini retriever
 
 class ResultsWriter:
     def __init__(self, results: List[Result], append: bool = False):
@@ -54,10 +50,6 @@ class ResultsWriter:
             results.append({"query": result.query, "hits": result.hits})
         with open(filename, "a" if self._append else "w") as f:
             json.dump(results, f, indent=2)
-<<<<<<< HEAD
-
-=======
->>>>>>> integrated result into pyserini retriever
 
     def write_in_trec_eval_format(self, filename: str):
         with open(filename, "a" if self._append else "w") as f:

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -29,6 +29,7 @@ class Result:
     def __repr__(self):
         return str(self.__dict__)
 
+
 class ResultsWriter:
     def __init__(self, results: List[Result], append: bool = False):
         self._results = results

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 class RankingExecInfo:
     def __init__(
         self, prompt, response: str, input_token_count: int, output_token_count: int
-    ) -> None:
+    ):
         self.prompt = prompt
         self.response = response
         self.input_token_count = input_token_count
@@ -25,6 +25,10 @@ class Result:
 
     def __repr__(self):
         return str(self.__dict__)
+<<<<<<< HEAD
+=======
+
+>>>>>>> integrated result into pyserini retriever
 
 class ResultsWriter:
     def __init__(self, results: List[Result], append: bool = False):
@@ -47,7 +51,10 @@ class ResultsWriter:
             results.append({"query": result.query, "hits": result.hits})
         with open(filename, "a" if self._append else "w") as f:
             json.dump(results, f, indent=2)
+<<<<<<< HEAD
 
+=======
+>>>>>>> integrated result into pyserini retriever
 
     def write_in_trec_eval_format(self, filename: str):
         with open(filename, "a" if self._append else "w") as f:

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 class RankingExecInfo:
     def __init__(
         self, prompt, response: str, input_token_count: int, output_token_count: int
-    ):
+    ) -> None:
         self.prompt = prompt
         self.response = response
         self.input_token_count = input_token_count
@@ -25,7 +25,6 @@ class Result:
 
     def __repr__(self):
         return str(self.__dict__)
-
 
 class ResultsWriter:
     def __init__(self, results: List[Result], append: bool = False):
@@ -48,6 +47,7 @@ class ResultsWriter:
             results.append({"query": result.query, "hits": result.hits})
         with open(filename, "a" if self._append else "w") as f:
             json.dump(results, f, indent=2)
+
 
     def write_in_trec_eval_format(self, filename: str):
         with open(filename, "a" if self._append else "w") as f:

--- a/src/rank_llm/result.py
+++ b/src/rank_llm/result.py
@@ -11,6 +11,9 @@ class RankingExecInfo:
         self.input_token_count = input_token_count
         self.output_token_count = output_token_count
 
+    def __repr__(self):
+        return str(self.__dict__)
+
 
 class Result:
     def __init__(

--- a/src/rank_llm/retrieve_and_rerank.py
+++ b/src/rank_llm/retrieve_and_rerank.py
@@ -100,13 +100,7 @@ def retrieve_and_rerank(
     reranker = Reranker(agent, top_k_candidates)
     for pass_ct in range(num_passes):
         print(f"Pass {pass_ct + 1} of {num_passes}:")
-        (
-            rerank_results,
-            input_token_counts,
-            output_token_counts,
-            aggregated_prompts,
-            aggregated_responses,
-        ) = reranker.rerank(
+        rerank_results = reranker.rerank(
             retrieved_results,
             rank_end=top_k_candidates,
             window_size=min(window_size, top_k_candidates),
@@ -120,10 +114,6 @@ def retrieve_and_rerank(
             file_name = reranker.write_rerank_results(
                 retrieval_method.name,
                 rerank_results,
-                input_token_counts,
-                output_token_counts,
-                aggregated_prompts,
-                aggregated_responses,
                 shuffle_candidates,
                 pass_ct=None if num_passes == 1 else pass_ct,
                 window_size=window_size,
@@ -148,5 +138,7 @@ def retrieve_and_rerank(
                 print(f"Skipping evaluation as {dataset} is not in TOPICS.")
         if num_passes > 1:
             retrieved_results = rerank_results
+            for r in retrieved_results:
+                r.ranking_exec_summary = None
 
     return rerank_results


### PR DESCRIPTION
This cl:

1- Changes all the reranking related classes to use `Result` and `ResultsWriter`
2- Instead of separate token_count and prompt_and_responses folders, the ranking exec summary is written in a single folder.
4- In addition to trec value format for the final rerank results, the sorted results file is also stored as a json
3- the evaluation script is fixed

Fixing response analysis script with come in a follow up cl
TESTED=ran run_rank_llm e2e