### PR TITLE
Merge LiT5 into RankLLM

### DIFF
--- a/src/rank_llm/rerank/lit5/data.py
+++ b/src/rank_llm/rerank/lit5/data.py
@@ -1,0 +1,115 @@
+import torch
+import random
+import json
+import numpy as np
+from .options import Options
+
+class Dataset(torch.utils.data.Dataset):
+    def __init__(self,
+                 data,
+                 n_passages=None,
+                 start_pos=0,
+                 question_prefix='question:',
+                 passage_prefix='context:',
+                 passage_numbering=False):
+        self.data = data
+        self.n_passages = n_passages
+        self.start_pos = start_pos
+        self.question_prefix = question_prefix
+        self.passage_prefix = passage_prefix
+        self.passage_numbering = passage_numbering
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, index):
+        example = self.data[index]
+        question = self.question_prefix + " " + example['question']
+
+        if 'ctxs' in example and self.n_passages is not None:
+            # add dummy contexts when there are not enough
+            while len(example['ctxs']) < self.start_pos+self.n_passages:
+                example['ctxs'].append({'text': ""})
+            
+            contexts = np.array(example['ctxs'][self.start_pos:self.start_pos+self.n_passages])
+
+            if self.passage_numbering:
+                f = self.passage_prefix + " [{}] {}"
+                passages = []
+                passage_id = 1
+                for c in contexts:
+                    passages.append(f.format(passage_id, c['text']))
+                    passage_id+=1
+            else:
+                f = self.passage_prefix + " {}"
+                passages = np.array([f.format(c['text']) for c in contexts])
+            
+        else:
+            passages = None
+        return {
+            'index' : index,
+            'question' : question,
+            'passages' : passages,
+        }
+
+def encode_passages(batch_text_passages, tokenizer, max_length, batch_size, n_passages):
+    passage_ids, passage_masks = [], []
+    for k, text_passages in enumerate(batch_text_passages):
+        p = tokenizer.batch_encode_plus(
+            text_passages,
+            max_length=max_length,
+            padding='max_length', 
+            return_tensors='pt',
+            truncation=True
+        )
+        passage_ids.append(p['input_ids'][None])
+        passage_masks.append(p['attention_mask'][None])
+
+    passage_ids = torch.cat(passage_ids, dim=0)
+    passage_masks = torch.cat(passage_masks, dim=0)
+    return passage_ids, passage_masks.bool()
+
+class Collator(object):
+    def __init__(self, text_maxlength, tokenizer, answer_maxlength=32, batch_size=1, n_passages=100, suffix=''):
+        self.tokenizer = tokenizer
+        self.text_maxlength = text_maxlength
+        self.answer_maxlength = answer_maxlength
+        self.batch_size = batch_size
+        self.n_passages = n_passages
+        self.suffix = suffix
+
+    def __call__(self, batch):
+        index = torch.tensor([ex['index'] for ex in batch])
+
+        def append_question(example):
+            if example['passages'] is None:
+                return [example['question']]
+            return [example['question'] + " " + t + self.suffix for t in example['passages']]
+        text_passages = [append_question(example) for example in batch]
+        query = [example['question'] for example in batch]
+        passage_ids, passage_masks = encode_passages(text_passages,
+                                                     self.tokenizer,
+                                                     self.text_maxlength,
+                                                     self.batch_size,
+                                                     self.n_passages)
+
+        return (index, passage_ids, passage_masks, query)
+
+def load_data(data_path):
+    if data_path.endswith('.jsonl'):
+        data = open(data_path, 'r')
+    elif data_path.endswith('.json'):
+        with open(data_path, 'r') as fin:
+            data = json.load(fin)
+    examples = []
+    for k, example in enumerate(data):
+        if data_path is not None and data_path.endswith('.jsonl'):
+            example = json.loads(example)
+        if not 'id' in example:
+            example['id'] = k
+        examples.append(example)
+
+    if data_path.endswith('.jsonl'):
+        data.close()
+
+    return examples

--- a/src/rank_llm/rerank/lit5/model.py
+++ b/src/rank_llm/rerank/lit5/model.py
@@ -1,0 +1,324 @@
+import types
+import torch
+import transformers
+import torch.nn.functional as F
+from torch import nn
+from torch.nn import CrossEntropyLoss
+import numpy as np
+import copy
+
+from lit5.options import Options
+
+options = Options()
+options.add_reader_options()
+options.add_eval_options()
+opt = options.parse()
+
+if opt.write_crossattention_scores:
+    from lit5.modeling_t5 import T5ForConditionalGeneration, T5Stack
+else:
+    from transformers.models.t5.modeling_t5 import T5ForConditionalGeneration, T5Stack
+
+    
+class FiDStack(T5Stack):
+    def __init__(self, config, embed_tokens=None):
+        super().__init__(config, embed_tokens=embed_tokens)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        inputs_embeds=None,
+        head_mask=None,
+        cross_attn_head_mask=None,
+        past_key_values=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+    ):
+        if not self.is_decoder:
+            input_ids = input_ids.view(input_ids.size(0) * self.config.n_passages, -1)
+            attention_mask = attention_mask.view(attention_mask.size(0) * self.config.n_passages, -1)
+        
+        output = super().forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            inputs_embeds=inputs_embeds,
+            head_mask=head_mask,
+            cross_attn_head_mask=cross_attn_head_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        
+        if not self.is_decoder:
+            bsz = input_ids.size(0) // self.config.n_passages
+            if not return_dict:
+                last_hidden_states = output[0]
+                last_hidden_state = last_hidden_states.view(bsz, -1, last_hidden_states.size(-1))
+                output = tuple(
+                    last_hidden_state,
+                    *output[1:],
+                )
+            else:
+                last_hidden_state = output.last_hidden_state
+                output.last_hidden_state = last_hidden_state.view(bsz, -1, last_hidden_state.size(-1))
+
+        return output
+
+
+class FiD(T5ForConditionalGeneration):
+    _keys_to_ignore_on_load_missing = [
+        r"encoder\.embed_tokens\.weight",
+        r"decoder\.embed_tokens\.weight",
+        r"lm_head\.weight",
+    ]
+    _keys_to_ignore_on_load_unexpected = [
+        r"decoder\.block\.0\.layer\.1\.EncDecAttention\.relative_attention_bias\.weight",
+    ]
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model_dim = config.d_model
+
+        self.shared = nn.Embedding(config.vocab_size, config.d_model)
+
+        self.config.n_passages = opt.n_passages
+        self.config.bsz = opt.batch_size
+        
+        encoder_config = copy.deepcopy(config)
+        encoder_config.is_decoder = False
+        encoder_config.use_cache = False
+        encoder_config.is_encoder_decoder = False
+        
+        self.encoder = FiDStack(encoder_config, self.shared)
+
+        decoder_config = copy.deepcopy(config)
+        decoder_config.is_decoder = True
+        decoder_config.is_encoder_decoder = False
+        decoder_config.use_cache = True
+        decoder_config.num_layers = config.num_decoder_layers
+        self.decoder = FiDStack(decoder_config, self.shared)
+
+        self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+        # Model parallel
+        self.model_parallel = False
+        self.device_map = None
+
+    def set_checkpoint(self, use_checkpoint):
+        """
+        Enable or disable checkpointing in the encoder.
+        See https://pytorch.org/docs/stable/checkpoint.html
+        """
+        for mod in self.encoder.encoder.block:
+            mod.use_checkpoint = use_checkpoint
+
+    def reset_score_storage(self):
+        """
+        Reset score storage, only used when cross-attention scores are saved
+        to train a retriever.
+        """
+        for mod in self.decoder.block:
+            mod.layer[1].EncDecAttention.normalized_score_storage = None
+
+    @torch.no_grad()
+    def get_crossattention_scores(self, n_passages, mask, ids, mask_query=None, output_sequence_lengths=[]):
+        """
+        Cross-attention scores are aggregated to obtain a single scalar per
+        passage. This scalar can be seen as a similarity score between the
+        question and the input passage. It is obtained by averaging the
+        cross-attention scores obtained on the first decoded token over heads,
+        layers, and tokens of the input passage.
+
+        More details in Distilling Knowledge from Reader to Retriever:
+        https://arxiv.org/abs/2012.04584.
+        """
+        norms = []
+        for mod in self.decoder.block:
+            norms.append(mod.layer[1].EncDecAttention.normalized_score_storage)
+        norms = torch.stack(norms)
+
+        output = {}
+        self.aggregate_value(norms, mask, n_passages, ids, mask_query, output, prefix="norms", output_sequence_lengths=output_sequence_lengths)
+        return output
+
+    def aggregate_value(self, scores, mask, n_passages, ids, mask_query=None, output={}, prefix="", output_sequence_lengths=[]):
+        n_layers, bsz, n_tokens, total_tokens = scores.size()
+
+        ids = ids.view(bsz, n_passages, -1)
+        scores = scores.view(n_layers, bsz, n_tokens, n_passages, -1)
+        mask = mask.view(bsz, n_passages, -1)
+        scores = scores.masked_fill(~mask[None, :, None], 0.0)
+
+        scores = scores.sum(dim=[0])
+
+        scores_woquery = None
+        # Compute scores based on scores without query
+        if not mask_query is None:
+            output[f"{prefix}woquery"]  = self.get_woquery_score(scores, mask_query, mask, n_layers, output_sequence_lengths=output_sequence_lengths)
+
+        return output
+
+
+    def get_woquery_score(self, scores, mask_query, mask, n_layers, output_sequence_lengths):
+        if scores.size(-1) > mask_query.size(-1):
+            zero_padding = torch.zeros(
+                [mask_query.size(0), scores.size(-1) - mask_query.size(-1)], device=mask_query.device, dtype=torch.bool
+            )
+            mask_query = torch.cat([mask_query, zero_padding], dim=-1)
+        mask_query = mask * (~mask_query[:, None])
+        scores_woquery = scores.masked_fill(~mask_query[:, None], 0.0)
+                
+        ntokens_woquery = 256 * n_layers
+        
+        # zero out scores after EOS token. This is needed when batching results in sequences with different lengths.
+        for i in range(len(scores_woquery)):
+            scores_woquery[i, output_sequence_lengths[i]:, :, :] = 0
+            
+        scores_woquery = scores_woquery.sum(dim=[1, 3])
+        return scores_woquery / ntokens_woquery
+
+    def overwrite_forward_crossattention(self):
+        """
+        Replace cross-attention forward function, only used to save
+        cross-attention scores.
+        """
+        for mod in self.decoder.block:
+            xattn = mod.layer[1].EncDecAttention
+            xattn.forward = types.MethodType(cross_attention_forward, xattn)
+
+    def create_crossattention_storage(self):
+        for mod in self.decoder.block:
+            xattn = mod.layer[1].EncDecAttention
+            xattn.normalized_score_storage = None
+
+def cross_attention_forward(
+    self,
+    hidden_states,
+    mask=None,
+    key_value_states=None,
+    position_bias=None,
+    past_key_value=None,
+    layer_head_mask=None,
+    query_length=None,
+    use_cache=False,
+    output_attentions=False,
+):
+    """
+    Self-attention (if key_value_states is None) or attention over source sentence (provided by key_value_states).
+    """
+    # Input is (batch_size, seq_length, dim)
+    # Mask is (batch_size, key_length) (non-causal) or (batch_size, key_length, key_length)
+    # past_key_value[0] is (batch_size, n_heads, q_len - 1, dim_per_head)
+    
+    batch_size, seq_length = hidden_states.shape[:2]
+    real_seq_length = seq_length
+
+    if past_key_value is not None:
+        assert (
+            len(past_key_value) == 2
+        ), f"past_key_value should have 2 past states: keys and values. Got { len(past_key_value)} past states"
+        real_seq_length += past_key_value[0].shape[2] if query_length is None else query_length
+
+    key_length = real_seq_length if key_value_states is None else key_value_states.shape[1]
+
+    def shape(states):
+        """projection"""
+        return states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+
+    def unshape(states):
+        """reshape"""
+        return states.transpose(1, 2).contiguous().view(batch_size, -1, self.inner_dim)
+
+    def project(hidden_states, proj_layer, key_value_states, past_key_value):
+        """projects hidden states correctly to key/query states"""
+        if key_value_states is None:
+            # self-attn
+            # (batch_size, n_heads, seq_length, dim_per_head)
+            hidden_states = shape(proj_layer(hidden_states))
+        elif past_key_value is None:
+            # cross-attn
+            # (batch_size, n_heads, seq_length, dim_per_head)
+            hidden_states = shape(proj_layer(key_value_states))
+
+        if past_key_value is not None:
+            if key_value_states is None:
+                # self-attn
+                # (batch_size, n_heads, key_length, dim_per_head)
+                hidden_states = torch.cat([past_key_value, hidden_states], dim=2)
+            else:
+                # cross-attn
+                hidden_states = past_key_value
+        return hidden_states
+
+    # get query states
+    query_states = shape(self.q(hidden_states))  # (batch_size, n_heads, seq_length, dim_per_head)
+
+    # get key/value states
+    key_states = project(
+        hidden_states, self.k, key_value_states, past_key_value[0] if past_key_value is not None else None
+    )
+    value_states = project(
+        hidden_states, self.v, key_value_states, past_key_value[1] if past_key_value is not None else None
+    )
+
+    # compute scores
+    scores = torch.matmul(
+        query_states, key_states.transpose(3, 2)
+    )  # equivalent of torch.einsum("bnqd,bnkd->bnqk", query_states, key_states), compatible with onnx op>9
+
+    
+    if position_bias is None:
+        if not self.has_relative_attention_bias:
+            position_bias = torch.zeros(
+                (1, self.n_heads, real_seq_length, key_length), device=scores.device, dtype=scores.dtype
+            )
+            if self.gradient_checkpointing and self.training:
+                position_bias.requires_grad = True
+        else:
+            position_bias = self.compute_bias(real_seq_length, key_length)
+
+        # if key and values are already calculated
+        # we want only the last query position bias
+        if past_key_value is not None:
+            position_bias = position_bias[:, :, -hidden_states.size(1) :, :]
+
+        if mask is not None:
+            position_bias = position_bias + mask  # (batch_size, n_heads, seq_length, key_length)
+
+    scores += position_bias
+
+    attn_weights = nn.functional.softmax(scores.float(), dim=-1)  # .type_as(scores)
+
+    if hasattr(self, "normalized_score_storage"):
+        with torch.no_grad():
+            self.normalized_score_storage = (
+                (torch.norm(value_states.float(), dim=-1)[:, :, None] * attn_weights).detach().mean(dim=1)
+            )
+
+    attn_weights = nn.functional.dropout(attn_weights.type_as(scores), p=self.dropout, training=self.training)
+
+    # Mask heads if we want to
+    if layer_head_mask is not None:
+        attn_weights = attn_weights * layer_head_mask
+
+    attn_output = unshape(torch.matmul(attn_weights, value_states))  # (batch_size, seq_length, dim)
+    attn_output = self.o(attn_output)
+
+    present_key_value_state = (key_states, value_states) if (self.is_decoder and use_cache) else None
+    outputs = (attn_output,) + (present_key_value_state,) + (position_bias,)
+
+    if output_attentions:
+        outputs = outputs + (attn_weights,)
+    return outputs

--- a/src/rank_llm/rerank/lit5_reranker.py
+++ b/src/rank_llm/rerank/lit5_reranker.py
@@ -72,7 +72,7 @@ class LiT5ScoreReranker:
         window_size: int = 20,
         runfile_path: str = "runs/run.${topics}_${firststage}_${model//\//}",
     ) -> None:
-        agent = RankFiDDistill(
+        agent = RankFiDScore(
             model=model_path,
             context_size=context_size,
             prompt_mode=prompt_mode,

--- a/src/rank_llm/rerank/lit5_reranker.py
+++ b/src/rank_llm/rerank/lit5_reranker.py
@@ -61,3 +61,60 @@ class LiT5DistillReranker:
             shuffle_candidates=shuffle_candidates,
             logging=logging
         )
+
+
+class LiT5ScoreReranker:
+    def __init__(
+        self,
+        model_path: str = "castorini/LiT5-Score-base",
+        context_size: int = 300,
+        prompt_mode: PromptMode = PromptMode.LiT5,
+        window_size: int = 20,
+        runfile_path: str = "runs/run.${topics}_${firststage}_${model//\//}",
+    ) -> None:
+        agent = RankFiDDistill(
+            model=model_path,
+            context_size=context_size,
+            prompt_mode=prompt_mode,
+            window_size=window_size,
+            runfile_path=runfile_path,
+        )
+        self._reranker = Reranker(agent)
+
+    def rerank(
+        self,
+        retrieved_results: List[Result],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        window_size: int = 20,
+        step: int = 10,
+        shuffle_candidates: bool = False,
+        logging: bool = False
+    ) -> List[Result]:
+        """
+        Reranks a list of retrieved results using the LiT5-Score model.
+
+        Args:
+            retrieved_results (List[Result]): The list of results to be reranked.
+            rank_start (int, optional): The starting rank for processing. Defaults to 0.
+            rank_end (int, optional): The end rank for processing. Defaults to 100.
+            window_size (int, optional): The size of each sliding window. Defaults to 20.
+            step (int, optional): The step size for moving the window. Defaults to 10.
+            shuffle_candidates (bool, optional): Whether to shuffle candidates before reranking. Defaults to False.
+            logging (bool, optional): Enables logging of the reranking process. Defaults to False.
+
+        Returns:
+            List[Result]: A list containing the reranked results.
+
+        Note:
+            check 'rerank' for implementation details of reranking process.
+        """
+        return self._reranker.rerank(
+            retrieved_results=retrieved_results,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            window_size=window_size,
+            step=step,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging
+        )

--- a/src/rank_llm/rerank/lit5_reranker.py
+++ b/src/rank_llm/rerank/lit5_reranker.py
@@ -1,0 +1,63 @@
+from typing import List
+
+from rank_llm.rerank.rank_fid import RankFiDDistill
+from rank_llm.rerank.rankllm import PromptMode
+from rank_llm.rerank.reranker import Reranker
+from rank_llm.result import Result
+
+
+class LiT5DistillReranker:
+    def __init__(
+        self,
+        model_path: str = "castorini/LiT5-Distill-base",
+        context_size: int = 300,
+        prompt_mode: PromptMode = PromptMode.LiT5,
+        window_size: int = 20,
+        runfile_path: str = "runs/run.${topics}_${firststage}_${model//\//}",
+    ) -> None:
+        agent = RankFiDDistill(
+            model=model_path,
+            context_size=context_size,
+            prompt_mode=prompt_mode,
+            window_size=window_size,
+            runfile_path=runfile_path,
+        )
+        self._reranker = Reranker(agent)
+
+    def rerank(
+        self,
+        retrieved_results: List[Result],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        window_size: int = 20,
+        step: int = 10,
+        shuffle_candidates: bool = False,
+        logging: bool = False
+    ) -> List[Result]:
+        """
+        Reranks a list of retrieved results using the LiT5-Distill model.
+
+        Args:
+            retrieved_results (List[Result]): The list of results to be reranked.
+            rank_start (int, optional): The starting rank for processing. Defaults to 0.
+            rank_end (int, optional): The end rank for processing. Defaults to 100.
+            window_size (int, optional): The size of each sliding window. Defaults to 20.
+            step (int, optional): The step size for moving the window. Defaults to 10.
+            shuffle_candidates (bool, optional): Whether to shuffle candidates before reranking. Defaults to False.
+            logging (bool, optional): Enables logging of the reranking process. Defaults to False.
+
+        Returns:
+            List[Result]: A list containing the reranked results.
+
+        Note:
+            check 'rerank' for implementation details of reranking process.
+        """
+        return self._reranker.rerank(
+            retrieved_results=retrieved_results,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            window_size=window_size,
+            step=step,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging
+        )

--- a/src/rank_llm/rerank/rank_fid.py
+++ b/src/rank_llm/rerank/rank_fid.py
@@ -45,7 +45,7 @@ class RankFiDDistill(RankLLM):
         self.answer_maxlength = 100
         self.n_passes = 1
     
-    # leave for now, the same code from LiT5-Distill.py
+    # code from LiT5-Distill.py
     def evaluate(self, model, dataset, dataloader, tokenizer):
         generated_permutations = []
 
@@ -67,7 +67,7 @@ class RankFiDDistill(RankLLM):
                     generated_permutations.append(output)
         return generated_permutations
 
-    # leave for now, the same code from LiT5-Distill.py
+    # code from LiT5-Distill.py
     def clean_response(self, response: str) -> str:
         new_response = ""
         for c in response:
@@ -78,7 +78,7 @@ class RankFiDDistill(RankLLM):
         new_response = new_response.strip()
         return new_response
     
-    # leave for now, the same code from LiT5-Distill.py
+    # code from LiT5-Distill.py
     def remove_duplicate(self, response: List[int]) -> List[int]:
         new_response = []
         for c in response:
@@ -119,6 +119,106 @@ class RankFiDDistill(RankLLM):
             return sum(len(self.tokenizer.encode(item['text'])) for item in prompt)
         else:
             raise ValueError("Prompt must be a string or a list of dictionaries with a 'text' key.")
+
+    def get_num_tokens(self, prompt: str) -> int:
+        return len(self._tokenizer.encode(prompt))
+
+
+class RankFiDScore(RankLLM):
+    def __init__(
+        self,
+        model_path: str,
+        context_size: int = 300,
+        prompt_mode: PromptMode = PromptMode.LiT5,  # Placeholder for actual mode
+        window_size: int = 20,
+        device: str = 'cuda',
+    ) -> None:
+        """
+         Creates instance of the RankFiDScore class, a specialized version of RankLLM designed from Lit5-Score.
+        """
+        super().__init__(model=model_path, context_size=context_size, prompt_mode=prompt_mode)
+        self.tokenizer = T5Tokenizer.from_pretrained(model_path)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_path).to(device)
+        self.window_size = window_size
+        self.device = device
+        self.batch_size = 1
+        self.stride = 10
+        self.answer_maxlength = 100
+        self.n_passes = 1
+    
+    # code from LiT5-Score.py
+    def evaluate(model, dataset, dataloader, tokenizer, opt):
+        if opt.write_crossattention_scores:
+            model.overwrite_forward_crossattention()
+            model.reset_score_storage() 
+
+        with torch.no_grad():
+            for i, batch in enumerate(dataloader):
+                (idx, passage_ids, passage_mask, query) = batch
+                passage_ids = passage_ids.contiguous().view(passage_ids.size(0), -1)
+                passage_mask = passage_mask.contiguous().view(passage_mask.size(0), -1)
+
+                if opt.write_crossattention_scores:
+                    model.reset_score_storage()
+
+                outputs = model.generate(
+                    input_ids=passage_ids.cuda(),
+                    attention_mask=passage_mask.cuda(),
+                    max_length=opt.answer_maxlength,
+                    do_sample=False
+                )
+                
+                # need to zero out scores after EOS token. This is needed when batching results in sequences with different lengths.
+                output_sequence_lengths = [] 
+                for output in outputs:
+                    length = 0
+                    for token in output:
+                        if token == 1: # EOS token
+                            break
+                        length += 1
+                    output_sequence_lengths.append(length)
+
+                if opt.write_crossattention_scores:
+                    query_mask_reader = (
+                        tokenizer.batch_encode_plus(
+                            query,
+                            max_length=opt.text_maxlength,
+                            padding="longest",
+                            truncation=True,
+                            return_tensors="pt",
+                            add_special_tokens=False,
+                        )["attention_mask"]
+                        .bool()
+                        .cuda()
+                    )
+
+                    crossattention_scores = model.get_crossattention_scores(opt.n_passages,
+                        mask=passage_mask.cuda(),
+                        ids=passage_ids.cuda(),
+                        mask_query=query_mask_reader.cuda(),
+                        output_sequence_lengths=output_sequence_lengths)
+                                            
+                for k, o in enumerate(outputs):
+                    example = dataset.data[idx[k]]
+                    if opt.write_crossattention_scores:
+                        for j in range(min(len(example['ctxs']), opt.n_passages)):
+                            for key in crossattention_scores:
+                                example['ctxs'][j][key] = crossattention_scores[key][k, j].item()
+
+    def run_llm(self, prompt: Union[str, List[Dict[str, str]]]) -> Tuple[str, int]:
+        """
+        Run the target language model with a passed in prompt.
+        """
+
+    def create_prompt(self, result: Result, rank_start: int, rank_end: int) -> Tuple[str, int]:
+        """
+        Create a prompt based on the result and given ranking range.
+        """
+
+    def get_num_tokens(self, prompt: Union[str, List[Dict[str, str]]]) -> int:
+        """
+        Abstract method to calculate the number of tokens contained in the given prompt.
+        """
 
     def get_num_tokens(self, prompt: str) -> int:
         return len(self._tokenizer.encode(prompt))

--- a/src/rank_llm/rerank/rank_fid.py
+++ b/src/rank_llm/rerank/rank_fid.py
@@ -1,0 +1,124 @@
+import torch
+import transformers
+
+torch.manual_seed(0)
+transformers.set_seed(0)
+
+import numpy as np
+from torch.utils.data import DataLoader, SequentialSampler
+
+import lit5.data
+import lit5.model
+
+import copy
+import json 
+from typing import List, Union, Dict, Any, Tuple
+
+from rank_llm.rerank.rankllm import PromptMode, RankLLM
+from rank_llm.result import Result
+
+if opt.write_crossattention_scores:
+    from lit5.modeling_t5 import T5ForConditionalGeneration, T5Stack
+else:
+    from transformers.models.t5.modeling_t5 import T5ForConditionalGeneration, T5Stack
+
+
+class RankFiDDistill(RankLLM):
+    def __init__(
+        self,
+        model_path: str,
+        context_size: int = 300,
+        prompt_mode: PromptMode = PromptMode.LiT5,  # Placeholder for actual mode
+        window_size: int = 20,
+        device: str = 'cuda',
+    ) -> None:
+        """
+         Creates instance of the RankFiDDistill class, a specialized version of RankLLM designed from Lit5-Distill.
+        """
+        super().__init__(model=model_path, context_size=context_size, prompt_mode=prompt_mode)
+        self.tokenizer = T5Tokenizer.from_pretrained(model_path)
+        self.model = AutoModelForSeq2SeqLM.from_pretrained(model_path).to(device)
+        self.window_size = window_size
+        self.device = device
+        self.batch_size = 1
+        self.stride = 10
+        self.answer_maxlength = 100
+        self.n_passes = 1
+    
+    # leave for now, the same code from LiT5-Distill.py
+    def evaluate(self, model, dataset, dataloader, tokenizer):
+        generated_permutations = []
+
+        with torch.no_grad():
+            for i, batch in enumerate(dataloader):
+                (idx, passage_ids, passage_mask, query) = batch
+                passage_ids = passage_ids.contiguous().view(passage_ids.size(0), -1)
+                passage_mask = passage_mask.contiguous().view(passage_mask.size(0), -1)
+
+                outputs = model.generate(
+                    input_ids=passage_ids.cuda(),
+                    attention_mask=passage_mask.cuda(),
+                    max_length=opt.answer_maxlength,
+                    do_sample=False
+                )
+
+                for k, o in enumerate(outputs):
+                    output = tokenizer.decode(o, skip_special_tokens=True)
+                    generated_permutations.append(output)
+        return generated_permutations
+
+    # leave for now, the same code from LiT5-Distill.py
+    def clean_response(self, response: str) -> str:
+        new_response = ""
+        for c in response:
+            if not c.isdigit():
+                new_response += " "
+            else:
+                new_response += c
+        new_response = new_response.strip()
+        return new_response
+    
+    # leave for now, the same code from LiT5-Distill.py
+    def remove_duplicate(self, response: List[int]) -> List[int]:
+        new_response = []
+        for c in response:
+            if c not in new_response:
+                new_response.append(c)
+        return new_response
+
+    def run_llm(self, prompt: Union[str, List[Dict[str, str]]]) -> Tuple[str, int]:
+        """
+        Run the target language model with a passed in prompt.
+        """
+        self.model.eval()
+        inputs = self.tokenizer(prompt, return_tensors='pt', padding=True, truncation=True, max_length=self.context_size).to(self.device)
+        outputs = self.model.generate(
+            **inputs,
+            max_length=self.answer_maxlength,
+            do_sample=False
+        )
+        decoded_outputs = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+        return decoded_outputs, outputs.shape[1]
+
+    def create_prompt(self, result: Result, rank_start: int, rank_end: int) -> Tuple[str, int]:
+        """
+        Create a prompt based on the result and given ranking range.
+        """
+        passages = [result.hits[i]['content'] for i in range(rank_start, rank_end)]
+        prompt = " ".join(passages)
+        prompt_length = self.get_num_tokens(prompt)
+        return prompt, prompt_length
+
+    def get_num_tokens(self, prompt: Union[str, List[Dict[str, str]]]) -> int:
+        """
+        Abstract method to calculate the number of tokens contained in the given prompt.
+        """
+        if isinstance(prompt, str):
+            return len(self.tokenizer.encode(prompt))
+        elif isinstance(prompt, list):
+            return sum(len(self.tokenizer.encode(item['text'])) for item in prompt)
+        else:
+            raise ValueError("Prompt must be a string or a list of dictionaries with a 'text' key.")
+
+    def get_num_tokens(self, prompt: str) -> int:
+        return len(self._tokenizer.encode(prompt))

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -15,6 +15,7 @@ class PromptMode(Enum):
     UNSPECIFIED = "unspecified"
     RANK_GPT = "rank_GPT"
     LRL = "LRL"
+    LiT5 = "LiT5"
 
     def __str__(self):
         return self.value

--- a/src/rank_llm/retrieve_and_rerank.py
+++ b/src/rank_llm/retrieve_and_rerank.py
@@ -60,6 +60,14 @@ def retrieve_and_rerank(
             window_size=window_size,
             system_message=system_message,
         )
+    elif "fid" in model_path.lower():
+        agent = RankFiDDistill(
+            model=model_path,
+            context_size=context_size,
+            prompt_mode=prompt_mode,
+            window_size=window_size,
+            device=device,
+        )
     else:
         raise ValueError(f"Unsupported model: {model_path}")
 

--- a/src/rank_llm/retrieve_and_rerank.py
+++ b/src/rank_llm/retrieve_and_rerank.py
@@ -60,8 +60,16 @@ def retrieve_and_rerank(
             window_size=window_size,
             system_message=system_message,
         )
-    elif "fid" in model_path.lower():
+    elif "fiddistill" in model_path.lower():
         agent = RankFiDDistill(
+            model=model_path,
+            context_size=context_size,
+            prompt_mode=prompt_mode,
+            window_size=window_size,
+            device=device,
+        )
+    elif "fidscore" in model_path.lower():
+        agent = RankFiDScore(
             model=model_path,
             context_size=context_size,
             prompt_mode=prompt_mode,


### PR DESCRIPTION
# Reference URA-Project
Issue 35 RankLLM: Merge LiT5 Models into RankLLM https://github.com/castorini/ura-projects/issues/35

The goal is to port LiT5-Distill and LiT5-Score over to RankLLM.
## Completed
- Synced the LiT5 integration structure with the latest master, from command-line execution to the rankllm class
- Built RankFiDDistill(RankLLM) and RankFiDScore(RankLLM) in rank_fid.py
- Built LiT5DistillReranker and LiT5ScoreReranker in lit5_reranker.py
## Next Steps
- Inherited functions in RankFiDDistill, like create_prompt and run_llm, still need adjustments and testing to ensure LiT5 performs correctly
- Implemented inherited functions in RankFiDScore
- Validate the process of using LiT5 models within RankLLM, ideally we have a central command so run LiT5 as `python src/rank_llm/scripts/run_rank_llm.py` with --args