### PR TITLE
Added Support for Bge-Reranker-v2 into RankLLM

### DIFF
--- a/src/rank_llm/rerank/pointwise/bge_reranker_v2.py
+++ b/src/rank_llm/rerank/pointwise/bge_reranker_v2.py
@@ -1,0 +1,144 @@
+import logging
+import math
+from typing import List, Tuple
+import torch
+
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from transformers.generation import GenerationConfig
+
+from rank_llm.data import Result
+from rank_llm.rerank.pointwise.pointwise_rankllm import PointwiseRankLLM
+
+logger = logging.getLogger(__name__)
+
+
+class BGE_RERANKER_V2(PointwiseRankLLM):
+    def __init__(
+        self,
+        model: str,
+        prompt_mode: str = "bge-reranker-v2",
+        context_size: int = 512,
+        device: str = "cuda",
+        batch_size: int = 32,
+        use_bf16: bool = False
+    ):
+        super().__init__(
+            model=model,
+            context_size=context_size,
+            prompt_mode=prompt_mode,
+            device=device,
+            batch_size=batch_size,
+        )
+
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path=self._model,
+            trust_remote_code=True
+        )
+        self._llm = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path=self._model,
+            trust_remote_code=True,
+            torch_dtype=torch.bfloat16 if use_bf16 else torch.float32
+        ).to(self._device)
+        self._llm.eval()
+        self._context_size = context_size
+
+    def run_llm_batched(
+        self,
+        prompts: List[str],
+    ) -> Tuple[List[str], List[int], List[float]]:
+        gen_cfg = GenerationConfig.from_model_config(self._llm.config)
+        gen_cfg.max_new_tokens = self.num_output_tokens()
+        gen_cfg.min_new_tokens = self.num_output_tokens()
+        gen_cfg.output_scores = True
+        gen_cfg.return_dict_in_generate = True
+        gen_cfg.do_sample = False
+
+        all_outputs = []
+        all_output_token_counts = []
+        all_scores = []
+
+        pairs = [[prompt.split("Document: ").pop(0).replace("<s> Query: ", ""), prompt.split("Document: ").pop().replace("Retrieve:", "")] for prompt in prompts]
+
+        with torch.no_grad():
+            token_prompts = self._tokenizer(
+                pairs, padding=True, truncation=True, return_tensors="pt", max_length=512
+            ).to(self._device)
+
+            token_prompts = token_prompts["input_ids"]
+
+            batch_outputs = self._llm.generate(token_prompts, generation_config=gen_cfg)
+
+        batch_output_ids = batch_outputs.sequences
+        batch_logits = batch_outputs.scores
+
+        batch_outputs = [
+            self._tokenizer.decode(
+                single_token_sequence,
+                skip_special_tokens=True,
+                spaces_between_special_tokens=False,
+            )
+            for single_token_sequence in batch_output_ids
+        ]
+
+        for logit_tensor in batch_logits[0]:
+            truth_logit = logit_tensor[1176]
+            false_logit = logit_tensor[6136]
+            score = math.exp(truth_logit) / (
+                math.exp(truth_logit) + math.exp(false_logit)
+            )
+            all_scores.append(score)
+            all_output_token_counts.append(self.num_output_tokens)
+
+        all_outputs.extend(batch_outputs)
+
+        return all_outputs, all_output_token_counts, all_scores
+
+    def run_llm(self, prompt: str) -> Tuple[str, int, float]:
+        gen_cfg = GenerationConfig.from_model_config(self._llm.config)
+        gen_cfg.max_new_tokens = self.num_output_tokens()
+        gen_cfg.min_new_tokens = self.num_output_tokens()
+        gen_cfg.output_scores = True
+        gen_cfg.return_dict_in_generate = True
+        gen_cfg.do_sample = False
+
+        token_prompt = self._tokenizer.encode(prompt, return_tensors="pt").to(
+            self._device
+        )
+        output = self._llm.generate(token_prompt, generation_config=gen_cfg)
+        output_ids = output.sequences
+        logits = output.scores
+
+        if self._llm.config.is_encoder_decoder:
+            output_ids = output_ids[0]
+            output_ids = output_ids[1:]
+
+        outputs = self._tokenizer.decode(
+            output_ids, skip_special_tokens=True, spaces_between_special_tokens=False
+        )
+        truth_logit = logits[0][0][1176]
+        false_logit = logits[0][0][6136]
+        score = math.exp(truth_logit) / (math.exp(truth_logit) + math.exp(false_logit))
+
+        return outputs, output_ids.size(0), score
+
+    def num_output_tokens(self) -> int:
+        return 1
+
+    def create_prompt(self, result: Result, index: int) -> Tuple[str, int]:
+        query = result.query.text
+        input = f"Query: {query} Document: {self.convert_doc_to_prompt_content(result.candidates[index].doc, max_length=self._context_size)}"
+        prompt = (
+            self._tokenizer.decode(
+                self._tokenizer.encode(input)[: (self._context_size - 32)]
+            )[:-4]
+            + " Relevant: "
+        )
+        prompt = prompt.replace("<unk>", "")
+
+        return prompt, self.get_num_tokens(prompt)
+
+    def get_num_tokens(self, prompt: str) -> int:
+        return len(self._tokenizer.encode(prompt))
+
+    def cost_per_1k_token(self, input_token: bool) -> float:
+        return 0

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -15,6 +15,7 @@ class PromptMode(Enum):
     LRL = "LRL"
     MONOT5 = "monot5"
     LiT5 = "LiT5"
+    BGE_RERANKER_V2= "bge-reranker-v2"
 
     def __str__(self):
         return self.value

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -347,19 +347,19 @@ class Reranker:
             )
             print(f"Completed loading {model_path}")
         
-        elif "bge-reranker-v2" in model_path.lower():
+        elif "bge-reranker" in model_path.lower():
             print(f"Loading {model_path} ...")
 
             keys_and_defaults=[
                 ("device", "cuda"),
-                ("use_bf16", True),
+                ("use_fp16", True),
                 ("prompt_mode", PromptMode.BGE_RERANKER_V2),
                 ("context_size", 512),
                 ("batch_size", 64)
             ]
             (
                 device,
-                use_bf16,
+                use_fp16,
                 prompt_mode,
                 context_size,
                 batch_size
@@ -369,7 +369,7 @@ class Reranker:
                 model=model_path,
                 prompt_mode=prompt_mode,
                 context_size=context_size,
-                use_bf16=use_bf16, 
+                use_fp16=use_fp16, 
                 batch_size=batch_size,
                 device=device
             )

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -11,6 +11,7 @@ from rank_llm.rerank import (
 from rank_llm.rerank.listwise import RankListwiseOSLLM, SafeOpenai
 from rank_llm.rerank.listwise.rank_fid import RankFiDDistill, RankFiDScore
 from rank_llm.rerank.pointwise.monot5 import MonoT5
+from rank_llm.rerank.pointwise.bge_reranker_v2 import BGE_RERANKER_V2
 from rank_llm.rerank.rankllm import RankLLM
 
 
@@ -345,6 +346,36 @@ class Reranker:
                 batched=vllm_batched,
             )
             print(f"Completed loading {model_path}")
+        
+        elif "bge-reranker-v2" in model_path.lower():
+            print(f"Loading {model_path} ...")
+
+            keys_and_defaults=[
+                ("device", "cuda"),
+                ("use_bf16", True),
+                ("prompt_mode", PromptMode.BGE_RERANKER_V2),
+                ("context_size", 512),
+                ("batch_size", 64)
+            ]
+            (
+                device,
+                use_bf16,
+                prompt_mode,
+                context_size,
+                batch_size
+            ) = extract_kwargs(keys_and_defaults, **kwargs)
+
+            agent = BGE_RERANKER_V2(
+                model=model_path,
+                prompt_mode=prompt_mode,
+                context_size=context_size,
+                use_bf16=use_bf16, 
+                batch_size=batch_size,
+                device=device
+            )
+
+            print(f"Completed loading {model_path}")
+
         elif model_path in ["unspecified", "rank_random", "rank_identity"]:
             # NULL reranker
             agent = None


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

ref: N/A

## Checklist Items

Before submitting your pull request, please review these items:

- [Y] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [Y] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [Y] Have you updated any relevant documentation or added new tests where needed?

# PR Type

* Type: Feature
* Description: Adds support for the [bge-reranker-v2](https://huggingface.co/BAAI/bge-reranker-v2-minicpm-layerwise) models on Hugging Face for pointwise reranking via rank_llm. All bge supported models are: [BAAI/bge-reranker-base](https://huggingface.co/BAAI/bge-reranker-base), [BAAI/bge-reranker-large](https://huggingface.co/BAAI/bge-reranker-large), [BAAI/bge-reranker-v2-m3](https://huggingface.co/BAAI/bge-reranker-v2-m3), [BAAI/bge-reranker-v2-gemma](https://huggingface.co/BAAI/bge-reranker-v2-gemma), and [BAAI/bge-reranker-v2-minicpm-layerwise](https://huggingface.co/BAAI/bge-reranker-v2-minicpm-layerwise). Now the above bge models can be run like any other pointwise reranker on rank_llm.

# Documentation

## Dependencies

Aside from rank_llm's general setup, install the following:

```bash
pip install -U FlagEmbedding
pip install transformers
```
    
## Running bge

We can run bge with a simple command in the rank_llm directory as follows:

```bash
python src/rank_llm/scripts/run_rank_llm.py --model_path=insert_model_name_on_hf --dataset=insert_dataset_path_or_name --retrieval_method=_insert_retrieval_method --prompt_mode=bge-reranker-v2
```

## Tests

Here are some tests on the Deep Learning 2019 dataset, just to make sure things work.

```bash
# base
python src/rank_llm/scripts/run_rank_llm.py --model_path=BAAI/bge-reranker-base --dataset=dl19 --retrieval_method=bm25 --prompt_mode=bge-reranker-v2

# large
python src/rank_llm/scripts/run_rank_llm.py --model_path=BAAI/bge-reranker-large --dataset=dl19 --retrieval_method=bm25 --prompt_mode=bge-reranker-v2

# m3
python src/rank_llm/scripts/run_rank_llm.py --model_path=BAAI/bge-reranker-v2-m3 --dataset=dl19 --retrieval_method=bm25 --prompt_mode=bge-reranker-v2

# gemma
python src/rank_llm/scripts/run_rank_llm.py --model_path=BAAI/bge-reranker-v2-gemma --dataset=dl19 --retrieval_method=bm25 --prompt_mode=bge-reranker-v2

# minicpm-layerwise
python src/rank_llm/scripts/run_rank_llm.py --model_path=BAAI/bge-reranker-v2-minicpm-layerwise --dataset=dl19 --retrieval_method=bm25 --prompt_mode=bge-reranker-v2
```
    