### PR TITLE
Fix lit5 & change logics about logits and use alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+nohup.out
+log
+scripts
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-nohup.out
-log
-scripts
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/rank_llm/rerank/identity_reranker.py
+++ b/src/rank_llm/rerank/identity_reranker.py
@@ -1,6 +1,7 @@
 import copy
 import random
-from typing import List
+from datetime import datetime
+from typing import Any, List
 
 from rank_llm.data import Request, Result
 
@@ -12,6 +13,8 @@ class IdentityReranker:
         rank_start: int = 0,
         rank_end: int = 100,
         shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
     ) -> List[Result]:
         """
         A trivial reranker that returns a subsection of the retrieved candidates list as-is or shuffled.
@@ -40,3 +43,15 @@ class IdentityReranker:
                 )
             results.append(rerank_result)
         return results
+
+    def get_name(self) -> str:
+        return "identity_reranker"
+
+    def get_output_filename(
+        self,
+        top_k_candidates: int,
+        dataset_name: str,
+        shuffle_candidates: bool,
+        **kwargs: Any,
+    ) -> str:
+        return f"identity_{datetime.isoformat(datetime.now())}"

--- a/src/rank_llm/rerank/listwise/listwise_rankllm.py
+++ b/src/rank_llm/rerank/listwise/listwise_rankllm.py
@@ -14,7 +14,8 @@ from rank_llm.rerank import PromptMode, RankLLM
 
 logger = logging.getLogger(__name__)
 
-ALPH_START_IDX = ord('A') - 1
+ALPH_START_IDX = ord("A") - 1
+
 
 class ListwiseRankLLM(RankLLM, ABC):
     """
@@ -36,7 +37,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         prompt_mode: PromptMode,
         num_few_shot_examples: int,
         window_size: int,
-        use_alpha: bool = False
+        use_alpha: bool = False,
     ) -> None:
         super().__init__(model, context_size, prompt_mode)
         self._num_few_shot_examples = num_few_shot_examples
@@ -81,7 +82,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         rank_start: int,
         rank_end: int,
         logging: bool = False,
-        populate_exec_summary: bool = False
+        populate_exec_summary: bool = False,
     ) -> List[Result]:
         """
         Runs the permutation pipeline on a batch of result objects within the passed in rank range.
@@ -192,7 +193,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         step: int,
         shuffle_candidates: bool = False,
         logging: bool = False,
-        populate_exec_summary: bool = False
+        populate_exec_summary: bool = False,
     ) -> List[Result]:
         """
         Applies the sliding window algorithm to the reranking process for a batch of result objects.
@@ -242,7 +243,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         step: int,
         shuffle_candidates: bool = False,
         logging: bool = False,
-        populate_exec_summary: bool = True
+        populate_exec_summary: bool = True,
     ) -> Result:
         """
         Applies the sliding window algorithm to the reranking process.
@@ -277,7 +278,7 @@ class ListwiseRankLLM(RankLLM, ABC):
                 start_pos,
                 end_pos,
                 logging,
-                populate_exec_summary=populate_exec_summary
+                populate_exec_summary=populate_exec_summary,
             )
             end_pos = end_pos - step
             start_pos = start_pos - step
@@ -368,7 +369,7 @@ class ListwiseRankLLM(RankLLM, ABC):
                 else:
                     new_response += c
             new_response = new_response.strip()
-            
+
         return new_response
 
     def _remove_duplicate(self, response: List[int]) -> List[int]:

--- a/src/rank_llm/rerank/listwise/listwise_rankllm.py
+++ b/src/rank_llm/rerank/listwise/listwise_rankllm.py
@@ -36,10 +36,12 @@ class ListwiseRankLLM(RankLLM, ABC):
         prompt_mode: PromptMode,
         num_few_shot_examples: int,
         window_size: int,
+        use_alpha: bool = False
     ) -> None:
         super().__init__(model, context_size, prompt_mode)
         self._num_few_shot_examples = num_few_shot_examples
         self._window_size = window_size
+        self._use_alpha = use_alpha
 
     def get_output_filename(
         self,
@@ -79,9 +81,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         rank_start: int,
         rank_end: int,
         logging: bool = False,
-        populate_exec_summary: bool = False,
-        use_logits: bool = False,
-        use_alpha: bool = False
+        populate_exec_summary: bool = False
     ) -> List[Result]:
         """
         Runs the permutation pipeline on a batch of result objects within the passed in rank range.
@@ -98,14 +98,14 @@ class ListwiseRankLLM(RankLLM, ABC):
         prompts = []
         logger.info("Loading prompts.")
         prompts = self.create_prompt_batched(
-            results, rank_start, rank_end, batch_size=32, use_alpha=use_alpha
+            results, rank_start, rank_end, batch_size=32
         )
         if logging:
             for prompt in prompts:
                 logger.debug(f"Prompt: {prompt[0]}\n")
         logger.info("Prompts loaded.")
         batched_results = self.run_llm_batched(
-            [prompt for prompt, _ in prompts], current_window_size=rank_end - rank_start, use_logits=use_logits, use_alpha=use_alpha
+            [prompt for prompt, _ in prompts], current_window_size=rank_end - rank_start
         )
 
         for index, (result, (prompt, in_token_count)) in enumerate(
@@ -121,7 +121,7 @@ class ListwiseRankLLM(RankLLM, ABC):
                     prompt, permutation, in_token_count, out_token_count
                 )
                 result.ranking_exec_summary.append(ranking_exec_info)
-            result = self.receive_permutation(result, permutation, rank_start, rank_end, use_alpha)
+            result = self.receive_permutation(result, permutation, rank_start, rank_end)
 
         return results
 
@@ -132,8 +132,6 @@ class ListwiseRankLLM(RankLLM, ABC):
         rank_end: int,
         logging: bool = False,
         populate_exec_summary: bool = True,
-        use_logits: bool = False,
-        use_alpha: bool = False
     ) -> Result:
         """
         Runs the permutation pipeline on the passed in result set within the passed in rank range.
@@ -147,11 +145,11 @@ class ListwiseRankLLM(RankLLM, ABC):
         Returns:
             Result: The processed result object after applying permutation.
         """
-        prompt, in_token_count = self.create_prompt(result, rank_start, rank_end, use_alpha)
+        prompt, in_token_count = self.create_prompt(result, rank_start, rank_end)
         if logging:
             logger.info(f"Prompt: {prompt}\n")
         permutation, out_token_count = self.run_llm(
-            prompt, current_window_size=rank_end - rank_start, use_logits=use_logits, use_alpha=use_alpha
+            prompt, current_window_size=rank_end - rank_start
         )
         if logging:
             print(f"Output: {permutation}")
@@ -160,7 +158,7 @@ class ListwiseRankLLM(RankLLM, ABC):
                 prompt, permutation, in_token_count, out_token_count
             )
             result.ranking_exec_summary.append(ranking_exec_info)
-        result = self.receive_permutation(result, permutation, rank_start, rank_end, use_alpha)
+        result = self.receive_permutation(result, permutation, rank_start, rank_end)
         return result
 
     def shuffle_and_rescore(
@@ -194,9 +192,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         step: int,
         shuffle_candidates: bool = False,
         logging: bool = False,
-        populate_exec_summary: bool = False,
-        use_logits: bool = False,
-        use_alpha: bool = False
+        populate_exec_summary: bool = False
     ) -> List[Result]:
         """
         Applies the sliding window algorithm to the reranking process for a batch of result objects.
@@ -231,7 +227,7 @@ class ListwiseRankLLM(RankLLM, ABC):
                 logger.info(f"start_pos: {start_pos}, end_pos: {end_pos}")
             start_pos = max(start_pos, rank_start)
             rerank_results = self.permutation_pipeline_batched(
-                rerank_results, start_pos, end_pos, logging, populate_exec_summary, use_logits, use_alpha
+                rerank_results, start_pos, end_pos, logging, populate_exec_summary
             )
             end_pos = end_pos - step
             start_pos = start_pos - step
@@ -246,9 +242,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         step: int,
         shuffle_candidates: bool = False,
         logging: bool = False,
-        populate_exec_summary: bool = True,
-        use_logits: bool = False,
-        use_alpha: bool = False
+        populate_exec_summary: bool = True
     ) -> Result:
         """
         Applies the sliding window algorithm to the reranking process.
@@ -283,9 +277,7 @@ class ListwiseRankLLM(RankLLM, ABC):
                 start_pos,
                 end_pos,
                 logging,
-                populate_exec_summary=populate_exec_summary,
-                use_logits=use_logits,
-                use_alpha=use_alpha
+                populate_exec_summary=populate_exec_summary
             )
             end_pos = end_pos - step
             start_pos = start_pos - step
@@ -360,9 +352,9 @@ class ListwiseRankLLM(RankLLM, ABC):
         ) / 1000.0
         return (cost, input_token_count + output_token_count)
 
-    def _clean_response(self, response: str, use_alpha: bool = False) -> str:
+    def _clean_response(self, response: str) -> str:
         new_response = ""
-        if use_alpha:
+        if self._use_alpha:
             for c in response:
                 if not c.isalpha():
                     new_response += " "
@@ -387,7 +379,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         return new_response
 
     def receive_permutation(
-        self, result: Result, permutation: str, rank_start: int, rank_end: int, use_alpha: bool = False
+        self, result: Result, permutation: str, rank_start: int, rank_end: int
     ) -> Result:
         """
         Processes and applies a permutation to the ranking results.
@@ -416,7 +408,7 @@ class ListwiseRankLLM(RankLLM, ABC):
         """
 
         # Parse and normalize the permutation indices
-        response = self._clean_response(permutation, use_alpha)
+        response = self._clean_response(permutation)
         response = [int(x) - 1 for x in response.split()]
         response = self._remove_duplicate(response)
 

--- a/src/rank_llm/rerank/listwise/lit5/model.py
+++ b/src/rank_llm/rerank/listwise/lit5/model.py
@@ -14,6 +14,10 @@ from .modeling_t5 import T5Stack as T5StackCrossAttentionScore
 class FiDStack(T5Stack):
     def __init__(self, config, embed_tokens=None):
         super().__init__(config, embed_tokens=embed_tokens)
+        self._n_passages = None
+    
+    def reset_n_passages(self, n_passages: int):
+        self._n_passages = n_passages
 
     def forward(
         self,
@@ -29,12 +33,12 @@ class FiDStack(T5Stack):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
-        n_passages: int = None,
+        cache_position=None
     ):
         if not self.is_decoder:
-            input_ids = input_ids.view(input_ids.size(0) * n_passages, -1)
+            input_ids = input_ids.view(input_ids.size(0) * self._n_passages, -1)
             attention_mask = attention_mask.view(
-                attention_mask.size(0) * n_passages, -1
+                attention_mask.size(0) * self._n_passages, -1
             )
 
         output = super().forward(
@@ -50,71 +54,11 @@ class FiDStack(T5Stack):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
+            cache_position=cache_position
         )
 
         if not self.is_decoder:
-            bsz = input_ids.size(0) // n_passages
-            if not return_dict:
-                last_hidden_states = output[0]
-                last_hidden_state = last_hidden_states.view(
-                    bsz, -1, last_hidden_states.size(-1)
-                )
-                output = tuple(
-                    last_hidden_state,
-                    *output[1:],
-                )
-            else:
-                last_hidden_state = output.last_hidden_state
-                output.last_hidden_state = last_hidden_state.view(
-                    bsz, -1, last_hidden_state.size(-1)
-                )
-
-        return output
-
-
-class FiDStackCrossAttentionScore(T5StackCrossAttentionScore):
-    def __init__(self, config, embed_tokens=None):
-        super().__init__(config, embed_tokens=embed_tokens)
-
-    def forward(
-        self,
-        input_ids=None,
-        attention_mask=None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
-        inputs_embeds=None,
-        head_mask=None,
-        cross_attn_head_mask=None,
-        past_key_values=None,
-        use_cache=None,
-        output_attentions=None,
-        output_hidden_states=None,
-        return_dict=None,
-        n_passages: int = None,
-    ):
-        if not self.is_decoder:
-            input_ids = input_ids.view(input_ids.size(0) * n_passages, -1)
-            attention_mask = attention_mask.view(
-                attention_mask.size(0) * n_passages, -1
-            )
-
-        output = super().forward(
-            input_ids=input_ids,
-            attention_mask=attention_mask,
-            encoder_hidden_states=encoder_hidden_states,
-            encoder_attention_mask=encoder_attention_mask,
-            inputs_embeds=inputs_embeds,
-            head_mask=head_mask,
-            cross_attn_head_mask=cross_attn_head_mask,
-            past_key_values=past_key_values,
-            use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
-        )
-
-        if not self.is_decoder:
-            bsz = input_ids.size(0) // n_passages
+            bsz = input_ids.size(0) // self._n_passages
             if not return_dict:
                 last_hidden_states = output[0]
                 last_hidden_state = last_hidden_states.view(
@@ -173,6 +117,10 @@ class FiD(T5ForConditionalGeneration):
         # Model parallel
         self.model_parallel = False
         self.device_map = None
+    
+    def reset_n_passages(self, n_passages: int):
+        self.encoder.reset_n_passages(n_passages)
+        self.decoder.reset_n_passages(n_passages)
 
     def set_checkpoint(self, use_checkpoint):
         """
@@ -290,6 +238,67 @@ class FiD(T5ForConditionalGeneration):
         for mod in self.decoder.block:
             xattn = mod.layer[1].EncDecAttention
             xattn.normalized_score_storage = None
+
+
+class FiDStackCrossAttentionScore(T5StackCrossAttentionScore):
+    def __init__(self, config, embed_tokens=None):
+        super().__init__(config, embed_tokens=embed_tokens)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        inputs_embeds=None,
+        head_mask=None,
+        cross_attn_head_mask=None,
+        past_key_values=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=None,
+        n_passages: int = None,
+    ):
+        if not self.is_decoder:
+            input_ids = input_ids.view(input_ids.size(0) * n_passages, -1)
+            attention_mask = attention_mask.view(
+                attention_mask.size(0) * n_passages, -1
+            )
+
+        output = super().forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            inputs_embeds=inputs_embeds,
+            head_mask=head_mask,
+            cross_attn_head_mask=cross_attn_head_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+
+        if not self.is_decoder:
+            bsz = input_ids.size(0) // n_passages
+            if not return_dict:
+                last_hidden_states = output[0]
+                last_hidden_state = last_hidden_states.view(
+                    bsz, -1, last_hidden_states.size(-1)
+                )
+                output = tuple(
+                    last_hidden_state,
+                    *output[1:],
+                )
+            else:
+                last_hidden_state = output.last_hidden_state
+                output.last_hidden_state = last_hidden_state.view(
+                    bsz, -1, last_hidden_state.size(-1)
+                )
+
+        return output
 
 
 class FiDCrossAttentionScore(T5ConditionalGenerationCrossAttentionScore):

--- a/src/rank_llm/rerank/listwise/lit5/model.py
+++ b/src/rank_llm/rerank/listwise/lit5/model.py
@@ -462,7 +462,7 @@ def cross_attention_forward(
     query_length=None,
     use_cache=False,
     output_attentions=False,
-    cache_position=None
+    cache_position=None,
 ):
     """
     Self-attention (if key_value_states is None) or attention over source sentence (provided by key_value_states).

--- a/src/rank_llm/rerank/listwise/lit5/model.py
+++ b/src/rank_llm/rerank/listwise/lit5/model.py
@@ -15,7 +15,7 @@ class FiDStack(T5Stack):
     def __init__(self, config, embed_tokens=None):
         super().__init__(config, embed_tokens=embed_tokens)
         self._n_passages = None
-    
+
     def reset_n_passages(self, n_passages: int):
         self._n_passages = n_passages
 
@@ -33,7 +33,7 @@ class FiDStack(T5Stack):
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
-        cache_position=None
+        cache_position=None,
     ):
         if not self.is_decoder:
             input_ids = input_ids.view(input_ids.size(0) * self._n_passages, -1)
@@ -54,7 +54,7 @@ class FiDStack(T5Stack):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
-            cache_position=cache_position
+            cache_position=cache_position,
         )
 
         if not self.is_decoder:
@@ -117,7 +117,7 @@ class FiD(T5ForConditionalGeneration):
         # Model parallel
         self.model_parallel = False
         self.device_map = None
-    
+
     def reset_n_passages(self, n_passages: int):
         self.encoder.reset_n_passages(n_passages)
         self.decoder.reset_n_passages(n_passages)

--- a/src/rank_llm/rerank/listwise/lit5/model.py
+++ b/src/rank_llm/rerank/listwise/lit5/model.py
@@ -315,14 +315,14 @@ class FiDCrossAttentionScore(T5ConditionalGenerationCrossAttentionScore):
         encoder_config.use_cache = False
         encoder_config.is_encoder_decoder = False
 
-        self.encoder = FiDStack(encoder_config, self.shared)
+        self.encoder = FiDStackCrossAttentionScore(encoder_config, self.shared)
 
         decoder_config = copy.deepcopy(config)
         decoder_config.is_decoder = True
         decoder_config.is_encoder_decoder = False
         decoder_config.use_cache = True
         decoder_config.num_layers = config.num_decoder_layers
-        self.decoder = FiDStack(decoder_config, self.shared)
+        self.decoder = FiDStackCrossAttentionScore(decoder_config, self.shared)
 
         self.lm_head = nn.Linear(config.d_model, config.vocab_size, bias=False)
 

--- a/src/rank_llm/rerank/listwise/lit5/model.py
+++ b/src/rank_llm/rerank/listwise/lit5/model.py
@@ -462,6 +462,7 @@ def cross_attention_forward(
     query_length=None,
     use_cache=False,
     output_attentions=False,
+    cache_position=None
 ):
     """
     Self-attention (if key_value_states is None) or attention over source sentence (provided by key_value_states).

--- a/src/rank_llm/rerank/listwise/rank_fid.py
+++ b/src/rank_llm/rerank/listwise/rank_fid.py
@@ -93,11 +93,11 @@ class RankFiDDistill(ListwiseRankLLM):
         }
 
         with torch.no_grad():
+            self._llm.reset_n_passages(n_passages=n_passages)
             outputs = self._llm.generate(
                 **inputs,
                 max_length=self._answer_maxlength,
                 do_sample=False,
-                n_passages=n_passages,
             )
 
         decoded_outputs = [

--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -123,7 +123,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 enforce_eager=False,
                 max_logprobs=30,
                 tensor_parallel_size=num_gpus,
-                gpu_memory_utilization=0.93
+                gpu_memory_utilization=0.93,
             )
             self._tokenizer = self._llm.get_tokenizer()
         elif sglang_batched and Engine is None:

--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -69,6 +69,8 @@ class RankListwiseOSLLM(ListwiseRankLLM):
          - window_size (int, optional): The window size for handling text inputs. Defaults to 20.
          - system_message (Optional[str], optional): Custom system message to be included in the prompt for additional
          instructions or context. Defaults to None.
+         - use_logits (bool, optional): Indicates whether to use logits or not. Defaults to False.
+         - use_alpha (bool, optional): Indicates whether to use alphabet ordering the prompts. Defaults to False.
          - vllm_batched (bool, optional): Indicates whether batched inference using VLLM is leveraged. Defaults to False.
          - sglang_batched (bool, optional): Indicates whether batched inference using SGLang is leveraged. Defaults to False.
 

--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -44,6 +44,8 @@ class RankListwiseOSLLM(ListwiseRankLLM):
         variable_passages: bool = False,
         window_size: int = 20,
         system_message: str = None,
+        use_logits: bool = False,
+        use_alpha: bool = False,
         vllm_batched: bool = False,
         sglang_batched: bool = False,
     ) -> None:
@@ -79,7 +81,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
         TODO: Make repetition_penalty configurable
         """
         super().__init__(
-            model, context_size, prompt_mode, num_few_shot_examples, window_size
+            model, context_size, prompt_mode, num_few_shot_examples, window_size, use_alpha=use_alpha
         )
         self._device = device
         self._vllm_batched = vllm_batched
@@ -88,6 +90,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
         self._variable_passages = variable_passages
         self._system_message = system_message
         self._output_token_estimate = None
+        self._use_logits = use_logits
 
         if num_few_shot_examples > 0:
             with open("data/output_v2_aug_filtered.jsonl", "r") as json_file:
@@ -133,8 +136,6 @@ class RankListwiseOSLLM(ListwiseRankLLM):
         rank_end: int = 100,
         shuffle_candidates: bool = False,
         logging: bool = False,
-        use_logits: bool = False,
-        use_alpha: bool = False,
         **kwargs: Any,
     ) -> List[Result]:
         top_k_retrieve: int = kwargs.get("top_k_retrieve", 50)
@@ -160,12 +161,10 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 step=step,
                 shuffle_candidates=shuffle_candidates,
                 logging=logging,
-                populate_exec_summary=populate_exec_summary,
-                use_logits=use_logits,
-                use_alpha=use_alpha
+                populate_exec_summary=populate_exec_summary
             )
         else:
-            if use_logits:
+            if self._use_logits:
                 raise TypeError("Reranking using logits of first identifier is currently only supported when vllm_batch=True")
 
             # Normal operation mode
@@ -179,15 +178,13 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                     step=step,
                     shuffle_candidates=shuffle_candidates,
                     logging=logging,
-                    populate_exec_summary=populate_exec_summary,
-                    use_logits=use_logits,
-                    use_alpha=use_alpha
+                    populate_exec_summary=populate_exec_summary
                 )
                 results.append(result)
             return results
 
-    def _evaluate_logits(self, logits: Dict[str, 'Logit'], use_alpha: bool, total: Tuple[int, int]) -> Tuple[str, Dict[int, float]]:
-        if use_alpha:
+    def _evaluate_logits(self, logits: Dict[str, 'Logit'], total: Tuple[int, int]) -> Tuple[str, Dict[int, float]]:
+        if self._use_alpha:
             evaluations = {
                 ord(logit.decoded_token): logit.logprob
                 for logit in logits.values()
@@ -210,16 +207,14 @@ class RankListwiseOSLLM(ListwiseRankLLM):
 
         return result_string, evaluations
 
-    def _get_logits_single_digit(self, output: RequestOutput, use_alpha: bool = False, effective_location: int = 1, total: Tuple[int, int] = (1, 9)):
+    def _get_logits_single_digit(self, output: RequestOutput, effective_location: int = 1, total: Tuple[int, int] = (1, 9)):
         logits = output.outputs[0].logprobs[effective_location]
-        return self._evaluate_logits(logits, use_alpha, total)
+        return self._evaluate_logits(logits, total)
 
     def run_llm_batched(
         self,
         prompts: List[str | List[Dict[str, str]]],
         current_window_size: Optional[int] = None,
-        use_logits: bool = False,
-        use_alpha: bool = False,
     ) -> List[Tuple[str, int]]:
         
         if isinstance(self._llm, LLM):
@@ -227,21 +222,21 @@ class RankListwiseOSLLM(ListwiseRankLLM):
             if current_window_size is None:
                 current_window_size = self._window_size
 
-            if use_logits:
+            if self._use_logits:
                 params = SamplingParams(
                     min_tokens=2,
                     max_tokens=2, 
                     temperature=0.0,
-                    logprobs=30,
+                    logprobs=30
                 )
                 outputs = self._llm.generate(prompts, sampling_params=params)
-                arr = [self._get_logits_single_digit(output, use_alpha=use_alpha) for output in outputs]
+                arr = [self._get_logits_single_digit(output) for output in outputs]
                 return [(s, len(s)) for s, __ in arr]
             else:
                 sampling_params = SamplingParams(
                     temperature=0.0,
-                    max_tokens=self.num_output_tokens(current_window_size, use_alpha),
-                    min_tokens=self.num_output_tokens(current_window_size, use_alpha),
+                    max_tokens=self.num_output_tokens(current_window_size),
+                    min_tokens=self.num_output_tokens(current_window_size),
                 )
                 outputs = self._llm.generate(prompts, sampling_params)
                 return [
@@ -252,8 +247,8 @@ class RankListwiseOSLLM(ListwiseRankLLM):
             logger.info(f"SGLang Generating!")
             sampling_params = {
                 "temperature": 0.0,
-                "max_new_tokens": self.num_output_tokens(current_window_size, use_alpha),
-                "min_new_tokens": self.num_output_tokens(current_window_size, use_alpha),
+                "max_new_tokens": self.num_output_tokens(current_window_size),
+                "min_new_tokens": self.num_output_tokens(current_window_size),
             }
             outputs = self._llm.generate(prompts, sampling_params)
             return [
@@ -263,22 +258,22 @@ class RankListwiseOSLLM(ListwiseRankLLM):
             ]
 
     def run_llm(
-        self, prompt: str, current_window_size: Optional[int] = None, use_logits: bool = False, use_alpha: bool = False
+        self, prompt: str, current_window_size: Optional[int] = None
     ) -> Tuple[str, int]:
         if current_window_size is None:
             current_window_size = self._window_size
 
-        if use_logits:
+        if self._use_logits:
             params = SamplingParams(min_tokens=1, max_tokens=1, temperature=0.0, logprobs=30)
             output = self._llm.generate([prompt+"["], sampling_params=params, use_tqdm=False)[0]
-            s, _ = self._get_logits_single_digit(output, effective_location=0, use_alpha=use_alpha)
+            s, _ = self._get_logits_single_digit(output, effective_location=0)
             return s, len(s)
         else:
             inputs = self._tokenizer([prompt])
             inputs = {k: torch.tensor(v).to(self._device) for k, v in inputs.items()}
             gen_cfg = GenerationConfig.from_model_config(self._llm.config)
-            gen_cfg.max_new_tokens = self.num_output_tokens(current_window_size, use_alpha)
-            gen_cfg.min_new_tokens = self.num_output_tokens(current_window_size, use_alpha)
+            gen_cfg.max_new_tokens = self.num_output_tokens(current_window_size)
+            gen_cfg.min_new_tokens = self.num_output_tokens(current_window_size)
             # gen_cfg.temperature = 0
             gen_cfg.do_sample = False
             output_ids = self._llm.generate(**inputs, generation_config=gen_cfg)
@@ -292,14 +287,14 @@ class RankListwiseOSLLM(ListwiseRankLLM):
             )
             return outputs, output_ids.size(0)
 
-    def num_output_tokens(self, current_window_size: Optional[int] = None, use_alpha : bool = False) -> int:
+    def num_output_tokens(self, current_window_size: Optional[int] = None) -> int:
         if current_window_size is None:
             current_window_size = self._window_size
 
         if self._output_token_estimate and self._window_size == current_window_size:
             return self._output_token_estimate
 
-        if use_alpha:
+        if self._use_alpha:
             token_str = " > ".join([f"[{i+1}]" for i in range(current_window_size)])
         else:
             token_str = " > ".join([f"[{chr(ALPH_START_IDX+i+1)}]" for i in range(current_window_size)])
@@ -311,14 +306,14 @@ class RankListwiseOSLLM(ListwiseRankLLM):
 
         return _output_token_estimate
 
-    def _add_prefix_prompt(self, query: str, num: int, use_alpha: bool = False) -> str:
-        if use_alpha:
+    def _add_prefix_prompt(self, query: str, num: int) -> str:
+        if self._use_alpha:
             return f"I will provide you with {num} passages, each indicated by a alphabetical identifier []. Rank the passages based on their relevance to the search query: {query}.\n"
         else:
             return f"I will provide you with {num} passages, each indicated by a numerical identifier []. Rank the passages based on their relevance to the search query: {query}.\n"
 
-    def _add_post_prompt(self, query: str, num: int, use_alpha: bool = False) -> str:
-        if use_alpha:
+    def _add_post_prompt(self, query: str, num: int) -> str:
+        if self._use_alpha:
             example_ordering = "[B] > [A]" if self._variable_passages else "[D] > [B]"
         else:
             example_ordering = "[2] > [1]" if self._variable_passages else "[4] > [2]"
@@ -345,7 +340,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
         return messages
 
     def create_prompt(
-        self, result: Result, rank_start: int, rank_end: int, use_alpha: bool = False
+        self, result: Result, rank_start: int, rank_end: int
     ) -> Tuple[str, int]:
         query = result.query.text
         query = self._replace_number(query)
@@ -357,24 +352,24 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 if self._system_message:
                     messages.append({"role": "system", "content": self._system_message})
                 messages = self._add_few_shot_examples_messages(messages)
-                prefix = self._add_prefix_prompt(query, num, use_alpha=use_alpha)
+                prefix = self._add_prefix_prompt(query, num)
                 rank = 0
                 input_context = f"{prefix}\n"
                 for cand in result.candidates[rank_start:rank_end]:
                     rank += 1
                     content = self.convert_doc_to_prompt_content(cand.doc, max_length)
                     
-                    identifier = chr(ALPH_START_IDX + rank) if use_alpha else str(rank)
+                    identifier = chr(ALPH_START_IDX + rank) if self._use_alpha else str(rank)
                     input_context += f"[{identifier}] {self._replace_number(content)}\n"
 
-                input_context += self._add_post_prompt(query, num, use_alpha=use_alpha)
+                input_context += self._add_post_prompt(query, num)
                 messages.append({"role": "user", "content": input_context})
 
                 prompt = self._tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
                 prompt = fix_text(prompt)
                 num_tokens = self.get_num_tokens(prompt)
                 if num_tokens <= self.max_tokens() - self.num_output_tokens(
-                    rank_end - rank_start, use_alpha
+                    rank_end - rank_start, self._use_alpha
                 ):
                     break
                 else:
@@ -383,7 +378,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                         (
                             num_tokens
                             - self.max_tokens()
-                            + self.num_output_tokens(rank_end - rank_start, use_alpha)
+                            + self.num_output_tokens(rank_end - rank_start, self._use_alpha)
                         )
                         // ((rank_end - rank_start) * 4),
                     )
@@ -392,7 +387,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 if self._system_message:
                     conv.set_system_message(self._system_message)
                 conv = self._add_few_shot_examples(conv)
-                prefix = self._add_prefix_prompt(query, num, use_alpha=use_alpha)
+                prefix = self._add_prefix_prompt(query, num)
                 rank = 0
                 input_context = f"{prefix}\n"
                 for cand in result.candidates[rank_start:rank_end]:
@@ -400,17 +395,17 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                     # For Japanese should cut by character: content = content[:int(max_length)]
                     content = self.convert_doc_to_prompt_content(cand.doc, max_length)
 
-                    identifier = chr(ALPH_START_IDX + rank) if use_alpha else str(rank)
+                    identifier = chr(ALPH_START_IDX + rank) if self._use_alpha else str(rank)
                     input_context += f"[{identifier}] {self._replace_number(content)}\n"
 
-                input_context += self._add_post_prompt(query, num, use_alpha=use_alpha)
+                input_context += self._add_post_prompt(query, num)
                 conv.append_message(conv.roles[0], input_context)
                 conv.append_message(conv.roles[1], None)
                 prompt = conv.get_prompt()
                 prompt = fix_text(prompt)
                 num_tokens = self.get_num_tokens(prompt)
                 if num_tokens <= self.max_tokens() - self.num_output_tokens(
-                    rank_end - rank_start, use_alpha
+                    rank_end - rank_start, self._use_alpha
                 ):
                     break
                 else:
@@ -419,7 +414,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                         (
                             num_tokens
                             - self.max_tokens()
-                            + self.num_output_tokens(rank_end - rank_start, use_alpha)
+                            + self.num_output_tokens(rank_end - rank_start, self._use_alpha)
                         )
                         // ((rank_end - rank_start) * 4),
                     )
@@ -430,8 +425,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
         results: List[Result],
         rank_start: int,
         rank_end: int,
-        batch_size: int = 32,
-        use_alpha: bool = False
+        batch_size: int = 32
     ) -> List[Tuple[str, int]]:
         def chunks(lst, n):
             """Yield successive n-sized chunks from lst."""
@@ -444,7 +438,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
             for batch in tqdm(chunks(results, batch_size), desc="Processing batches"):
                 completed_prompts = list(
                     executor.map(
-                        lambda result: self.create_prompt(result, rank_start, rank_end, use_alpha=use_alpha),
+                        lambda result: self.create_prompt(result, rank_start, rank_end),
                         batch,
                     )
                 )

--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -121,6 +121,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 enforce_eager=False,
                 max_logprobs=30,
                 tensor_parallel_size=num_gpus,
+                gpu_memory_utilization=0.93
             )
             self._tokenizer = self._llm.get_tokenizer()
         elif sglang_batched and Engine is None:
@@ -400,7 +401,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 prompt = fix_text(prompt)
                 num_tokens = self.get_num_tokens(prompt)
                 if num_tokens <= self.max_tokens() - self.num_output_tokens(
-                    rank_end - rank_start, self._use_alpha
+                    rank_end - rank_start
                 ):
                     break
                 else:

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -1,4 +1,3 @@
-import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -382,6 +382,8 @@ class Reranker:
                 ("window_size", 20),
                 ("system_message", None),
                 ("vllm_batched", True),
+                ("use_logits", False),
+                ("use_alpha", False)
             ]
             [
                 context_size,
@@ -393,6 +395,8 @@ class Reranker:
                 window_size,
                 system_message,
                 vllm_batched,
+                use_logits,
+                use_alpha
             ] = extract_kwargs(keys_and_defaults, **kwargs)
 
             agent = RankListwiseOSLLM(
@@ -406,6 +410,8 @@ class Reranker:
                 variable_passages=variable_passages,
                 window_size=window_size,
                 system_message=system_message,
+                use_logits=use_logits,
+                use_alpha=use_alpha,
                 vllm_batched=vllm_batched,
             )
 

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -383,7 +383,7 @@ class Reranker:
                 ("system_message", None),
                 ("vllm_batched", True),
                 ("use_logits", False),
-                ("use_alpha", False)
+                ("use_alpha", False),
             ]
             [
                 context_size,
@@ -396,7 +396,7 @@ class Reranker:
                 system_message,
                 vllm_batched,
                 use_logits,
-                use_alpha
+                use_alpha,
             ] = extract_kwargs(keys_and_defaults, **kwargs)
 
             agent = RankListwiseOSLLM(

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -14,6 +14,7 @@ from rank_llm.rerank.listwise.rank_fid import RankFiDDistill, RankFiDScore
 from rank_llm.rerank.pointwise.monot5 import MonoT5
 from rank_llm.rerank.rankllm import RankLLM
 
+
 class Reranker:
     def __init__(self, agent: Optional[RankLLM]) -> None:
         self._agent = agent
@@ -238,7 +239,7 @@ class Reranker:
                 ("vllm_batched", False),
                 ("sglang_batched", False),
                 ("use_logits", False),
-                ("use_alpha", False)
+                ("use_alpha", False),
             ]
             [
                 context_size,
@@ -252,7 +253,7 @@ class Reranker:
                 vllm_batched,
                 sglang_batched,
                 use_logits,
-                use_alpha
+                use_alpha,
             ] = extract_kwargs(keys_and_defaults, **kwargs)
 
             agent = RankListwiseOSLLM(
@@ -273,7 +274,7 @@ class Reranker:
                 vllm_batched=vllm_batched,
                 sglang_batched=sglang_batched,
                 use_logits=use_logits,
-                use_alpha=use_alpha
+                use_alpha=use_alpha,
             )
 
             print(f"Completed loading {model_path}")
@@ -396,9 +397,7 @@ class Reranker:
             ] = extract_kwargs(keys_and_defaults, **kwargs)
 
             agent = RankListwiseOSLLM(
-                model=(
-                    model_path
-                ),
+                model=(model_path),
                 name=model_path,
                 context_size=context_size,
                 prompt_mode=prompt_mode,

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -25,8 +25,6 @@ class Reranker:
         rank_end: int = 100,
         shuffle_candidates: bool = False,
         logging: bool = False,
-        use_logits: bool = False,
-        use_alpha: bool = False,
         **kwargs: Any,
     ) -> List[Result]:
         """
@@ -51,12 +49,8 @@ class Reranker:
         Returns:
             List[Result]: A list containing the reranked candidates.
         """
-        if use_logits and not isinstance(self._agent, RankListwiseOSLLM):
-            raise TypeError("Reranking using logits of first identifier is currently only supported by RankListwiseOSLLM.")
-        if use_logits and not use_alpha:
-            warnings.warn("You are reranking with the logits of the first identifier only but using numerical identifiers. It is recommended that you use alphabetical identifiers instead.", UserWarning)
         return self._agent.rerank_batch(
-            requests, rank_start, rank_end, shuffle_candidates, logging, use_logits, use_alpha, **kwargs
+            requests, rank_start, rank_end, shuffle_candidates, logging, **kwargs
         )
 
     def rerank(
@@ -223,51 +217,6 @@ class Reranker:
                 keys=openai_keys,
                 **(get_azure_openai_args() if use_azure_openai else {}),
             )
-        elif vllm_batched:
-            # supports loading models from huggingface
-            print(f"Loading {model_path} ...")
-            keys_and_defaults = [
-                ("context_size", 4096),
-                ("prompt_mode", PromptMode.RANK_GPT),
-                ("num_few_shot_examples", 0),
-                ("device", "cuda"),
-                ("num_gpus", 1),
-                ("variable_passages", False),
-                ("window_size", 20),
-                ("system_message", None),
-                ("vllm_batched", True),
-            ]
-            [
-                context_size,
-                prompt_mode,
-                num_few_shot_examples,
-                device,
-                num_gpus,
-                variable_passages,
-                window_size,
-                system_message,
-                vllm_batched,
-            ] = extract_kwargs(keys_and_defaults, **kwargs)
-
-            agent = RankListwiseOSLLM(
-                model=(
-                    model_path
-                ),
-                name=model_path,
-                context_size=context_size,
-                prompt_mode=prompt_mode,
-                num_few_shot_examples=num_few_shot_examples,
-                device=device,
-                num_gpus=num_gpus,
-                variable_passages=variable_passages,
-                window_size=window_size,
-                system_message=system_message,
-                vllm_batched=vllm_batched,
-            )
-
-            print(f"Completed loading {model_path}")
-
-
         elif "vicuna" in model_path or "zephyr" in model_path:
             # RankVicuna or RankZephyr model suite
             print(f"Loading {model_path} ...")
@@ -288,6 +237,8 @@ class Reranker:
                 ("system_message", None),
                 ("vllm_batched", False),
                 ("sglang_batched", False),
+                ("use_logits", False),
+                ("use_alpha", False)
             ]
             [
                 context_size,
@@ -300,6 +251,8 @@ class Reranker:
                 system_message,
                 vllm_batched,
                 sglang_batched,
+                use_logits,
+                use_alpha
             ] = extract_kwargs(keys_and_defaults, **kwargs)
 
             agent = RankListwiseOSLLM(
@@ -319,6 +272,8 @@ class Reranker:
                 system_message=system_message,
                 vllm_batched=vllm_batched,
                 sglang_batched=sglang_batched,
+                use_logits=use_logits,
+                use_alpha=use_alpha
             )
 
             print(f"Completed loading {model_path}")
@@ -413,6 +368,49 @@ class Reranker:
                 device=device,
                 batched=vllm_batched,
             )
+            print(f"Completed loading {model_path}")
+        elif vllm_batched:
+            # supports loading models from huggingface
+            print(f"Loading {model_path} ...")
+            keys_and_defaults = [
+                ("context_size", 4096),
+                ("prompt_mode", PromptMode.RANK_GPT),
+                ("num_few_shot_examples", 0),
+                ("device", "cuda"),
+                ("num_gpus", 1),
+                ("variable_passages", False),
+                ("window_size", 20),
+                ("system_message", None),
+                ("vllm_batched", True),
+            ]
+            [
+                context_size,
+                prompt_mode,
+                num_few_shot_examples,
+                device,
+                num_gpus,
+                variable_passages,
+                window_size,
+                system_message,
+                vllm_batched,
+            ] = extract_kwargs(keys_and_defaults, **kwargs)
+
+            agent = RankListwiseOSLLM(
+                model=(
+                    model_path
+                ),
+                name=model_path,
+                context_size=context_size,
+                prompt_mode=prompt_mode,
+                num_few_shot_examples=num_few_shot_examples,
+                device=device,
+                num_gpus=num_gpus,
+                variable_passages=variable_passages,
+                window_size=window_size,
+                system_message=system_message,
+                vllm_batched=vllm_batched,
+            )
+
             print(f"Completed loading {model_path}")
         elif model_path in ["unspecified", "rank_random", "rank_identity"]:
             # NULL reranker

--- a/src/rank_llm/retrieve/pyserini_retriever.py
+++ b/src/rank_llm/retrieve/pyserini_retriever.py
@@ -11,16 +11,10 @@ from pyserini.prebuilt_index_info import (
     TF_INDEX_INFO,
 )
 from pyserini.query_iterator import DefaultQueryIterator
-from pyserini.search import (
-    get_qrels,
-    get_topics,
-)
+from pyserini.search import get_qrels, get_topics
 from pyserini.search.faiss import FaissSearcher
 from pyserini.search.faiss._searcher import QueryEncoder
-from pyserini.search.lucene import (
-    LuceneImpactSearcher,
-    LuceneSearcher
-)
+from pyserini.search.lucene import LuceneImpactSearcher, LuceneSearcher
 from tqdm import tqdm
 
 from rank_llm.data import Candidate, DataWriter, Query, Request
@@ -182,7 +176,9 @@ class PyseriniRetriever:
             base_index = FAISS_INDEX_INFO[index_path]["texts"]
             self._index_reader = LuceneIndexReader.from_prebuilt_index(base_index)
         else:
-            raise ValueError(f"Could not build LuceneIndexReader from topics: {topics_path}")
+            raise ValueError(
+                f"Could not build LuceneIndexReader from topics: {topics_path}"
+            )
 
     def _init_custom_topics(self, topics_path: str, index_path: str):
         self._topics = DefaultQueryIterator.from_topics(topics_path).topics
@@ -210,7 +206,9 @@ class PyseriniRetriever:
             topics_key = TOPICS[dataset]
         self._topics = get_topics(topics_key)
         self._qrels = get_qrels(TOPICS[dataset])
-        self._index_reader = LuceneIndexReader.from_prebuilt_index(self._get_index("bm25"))
+        self._index_reader = LuceneIndexReader.from_prebuilt_index(
+            self._get_index("bm25")
+        )
 
     def _get_index(self, key: str = None) -> str:
         if not key:

--- a/src/rank_llm/retrieve/service_retriever.py
+++ b/src/rank_llm/retrieve/service_retriever.py
@@ -60,8 +60,8 @@ class ServiceRetriever:
             ValueError: If the retrieval mode is invalid or the result format is not as expected.
         """
 
-        url = f"{host}/api/collection/{dataset}/search?query={parse.quote(request.query.text)}&hits={str(k)}&qid={request.query.qid}"
-
+        url = f"{host}/api/v1.0/indexes/{dataset}/search?query={parse.quote(request.query.text)}&hits={str(k)}&qid={request.query.qid}"
+        print(url)
         try:
             response = requests.get(url, timeout=timeout)
             response.raise_for_status()


### PR DESCRIPTION
- Fixes #151
- Changes the logic about use_logits, and use_alpha. Put use_alpha into ListwiseRankLLM `__init__`, and put use_logits into RankListwiseOSLLM `__init__`. This is because put into ListwiseLLM will damage the method signature of parent classes and cause compatibility issue on LiT5
- Fix LiT5's Score's buggy code

**Notice**

LiT5 cannot support any multithread code, cause the object stores the state inside its model.

Performance Check:
```
python src/rank_llm/scripts/run_rank_llm.py  --model_path=castorini/LiT5-Score-large --top_k_candidates=100 --dataset=dl19     --retrieval_method=bm25 --prompt_mode=LiT5 --context_size=150 --vllm_batched --batch_size=4  --window_size=100 --variable_passages
Results:
ndcg_cut_10             all     0.7225
```

```
# Not able to run windowsize = 100 due to gpu issue, so can only test windowsize=20
python src/rank_llm/scripts/run_rank_llm.py  --model_path=castorini/LiT5-Distill-large-v2 --top_k_candidates=100 --dataset=dl19     --retrieval_method=bm25 --prompt_mode=LiT5  --context_size=150 --vllm_batched --batch_size=24     --variable_passages --window_size=20
Results:
ndcg_cut_10             all     0.7220
```

```
# Extra test on FIRST method to prove the use_logits change is working
python src/rank_llm/scripts/run_rank_llm.py  --model_path=castorini/first_mistral --top_k_candidates=100 --dataset=dl20 --retrieval_method=SPLADE++_EnsembleDistil_ONNX --prompt_mode=rank_GPT  --context_size=4096 --variable_passages --use_logits --use_alpha --vllm_batched --num_gpus 1
Results:
ndcg_cut_10             all     0.7885
```