### PR TITLE
rank_llm onboarding

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -167,3 +167,4 @@ A reminder that this is just a gentle introduction, and the field is still large
 ## Reproduction Log[*](https://github.com/castorini/pyserini/blob/master/docs/reproducibility.md)
 + Results reproduced by [@b8zhong](https://github.com/b8zhong) on 2025-02-03 (commit [`c908de0`](https://github.com/castorini/rank_llm/commit/c908de0423747a3863ca288b072e4580b3a3adef))
 + Results reproduced by [@vincent-4](https://github.com/vincent-4) on 2025-02-05 (commit [`4da0c46`](https://github.com/castorini/rank_llm/commit/4da0c46486fb31b65d41ec9a1fde7dacd9a05410))
++ Results reproduced by [@mithildamani256](https://github.com/mithildamani256) on 2025-02-15 (commit [`c91c011`](https://github.com/castorini/rank_llm/commit/c91c011ef5a60474144f9235551543d7fdd5c612))


### PR DESCRIPTION
The scores I got back very slightly differ from the given scores for both FirstMistral and RankZephyr. 

Scores - 
FirstMistral - 0.7843
RankZephyr - 0.8197

Apart from that, everything worked well. 