### PR TITLE
fix indentation error with num_passes > 1

### DIFF
--- a/src/rank_llm/retrieve_and_rerank.py
+++ b/src/rank_llm/retrieve_and_rerank.py
@@ -83,11 +83,11 @@ def retrieve_and_rerank(
                 **kwargs,
             )
 
-        if num_passes > 1:
-            requests = [
-                Request(copy.deepcopy(r.query), copy.deepcopy(r.candidates))
-                for r in rerank_results
-            ]
+            if num_passes > 1:
+                requests = [
+                    Request(copy.deepcopy(r.query), copy.deepcopy(r.candidates))
+                    for r in rerank_results
+                ]
 
     for rr in rerank_results:
         rr.candidates = rr.candidates[:top_k_rerank]


### PR DESCRIPTION
Previously, the rank_llm codebase was not correctly handling experiments when the `--num_passes` option was set to greater than 1. It was because there was an **indentation error** in the block of code responsible for updating and replacing the candidate requests for subsequent passes.

Specifically, the original code snippet for replacing `requests` (variable for candidate passages) was placed **outside** the for loop, and as a result, the model always executed as if only a single pass was requested, producing **identical results** every time, regardless of the num_passes setting.

The fix involves correcting the indentation of this specific code block, within the for loop (`for pass_ct in range(num_passes):`). With this adjustment, each iteration correctly updates the candidate set, leveraging the results from the previous iteration.


# Pull Request Checklist

## Reference Issue

Please provide the reference to issue this PR is addressing (# followed by the issue number). If there is no associated issue, write "N/A".

ref: N/A

## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... 
    - Description: 

    
  