### PR TITLE
Added InsertRank reranker experimentation with BM25 score integration

### DIFF
--- a/src/rank_llm/rerank/listwise/insertrank_reranker.py
+++ b/src/rank_llm/rerank/listwise/insertrank_reranker.py
@@ -1,0 +1,110 @@
+from typing import List, Dict, Any, Tuple
+from rank_llm.rerank.listwise.rank_listwise_os_llm import RankListwiseOSLLM
+from rank_llm.data import Request, Result, Candidate, Query
+from rank_llm.rerank import PromptMode
+
+class InsertRankReranker(RankListwiseOSLLM):
+    def __init__(self, model_path: str, **kwargs):
+        # remove deprecated params - we don't need template since we override create_prompt anyway
+        kwargs.pop('prompt_mode', None)
+        kwargs.pop('prompt_template_path', None)
+        
+        # just use the same init as the parent class
+        super().__init__(
+            model=model_path,
+            name=f"insertrank_{model_path.split('/')[-1]}",
+            **kwargs
+        )
+    
+    def create_insertrank_listwise_prompt(self, query: str, candidates: List[Candidate], max_length: int = 300):
+        """create insertrank prompt following the paper format"""
+        
+        # follow the paper's format - start with telling the model about bm25 scores
+        prompt = f"You are also given the BM25 scores from a lexical retrieval system.\n\n"
+        prompt += f"Query: {query}\n\n"
+        
+        # add each doc with its bm25 score (candidates should already be sorted by bm25)
+        # paper puts document content first, then the score below it
+        for i, candidate in enumerate(candidates):
+            content = self.convert_doc_to_prompt_content(candidate.doc, max_length)
+            prompt += f"[{i+1}]. {content}\nBM25 score: {candidate.score:.3f}\n\n"
+        
+        prompt += f"Rerank the above {len(candidates)} passages based on their relevance to the query. "
+        prompt += "Consider both the document content and the BM25 scores as signals for relevance. "
+        prompt += f"Return the ranking as a list of numbers from 1 to {len(candidates)}, most relevant first."
+        
+        return prompt
+    
+    def convert_doc_to_prompt_content(self, doc: Dict[str, Any], max_length: int) -> str:
+        """extract content from document for the prompt"""
+        # try different field names that might contain the document text
+        if "text" in doc:
+            content = doc["text"]
+        elif "segment" in doc:
+            content = doc["segment"]
+        elif "contents" in doc:
+            content = doc["contents"]
+        else:
+            content = str(doc)  # fallback
+        
+        # cut it short if its too long
+        if len(content) > max_length:
+            content = content[:max_length] + "..."
+            
+        # prepend title if we have one
+        if "title" in doc and doc["title"]:
+            content = f"Title: {doc['title']} Content: {content}"
+            
+        return content.strip()
+    
+    
+    def create_prompt(self, result: Result, rank_start: int, rank_end: int) -> Tuple[str, int]:
+        """override create_prompt to use our custom insertrank format"""
+        
+        candidates = result.candidates[rank_start:rank_end]
+        query_text = result.query.text
+        
+        # use our custom prompt that includes bm25 scores
+        prompt = self.create_insertrank_listwise_prompt(query_text, candidates)
+        
+        return prompt, len(candidates)
+
+    
+    def parse_reranking_response(self, response: str, original_candidates: List[Candidate]) -> List[Candidate]:
+        """parse the llm response to get the reranked candidates"""
+        
+        try:
+            # sometimes the response comes as a tuple, handle that
+            if isinstance(response, tuple):
+                response_str = str(response[0])
+            else:
+                response_str = str(response).strip()
+            
+            # extract all numbers from response - should be something like "1, 3, 2, 4, 5" or "[1, 3, 2, 4, 5]"
+            import re
+            numbers = re.findall(r'\d+', response_str)
+            rankings = [int(num) for num in numbers if 1 <= int(num) <= len(original_candidates)]
+            
+            # reorder the candidates based on what the llm said
+            if len(rankings) >= len(original_candidates):
+                reranked = []
+                used_indices = set()
+                
+                # go through the rankings and add candidates in that order
+                for rank in rankings[:len(original_candidates)]:
+                    idx = rank - 1  # convert to 0-based indexing
+                    if 0 <= idx < len(original_candidates) and idx not in used_indices:
+                        reranked.append(original_candidates[idx])
+                        used_indices.add(idx)
+                
+                # if we missed any candidates somehow, add them at the end
+                for i, candidate in enumerate(original_candidates):
+                    if i not in used_indices:
+                        reranked.append(candidate)
+                
+                return reranked
+            else:
+                return original_candidates  # not enough rankings, just return original
+                
+        except Exception as e:
+            return original_candidates  # something went wrong, return original order

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -17,6 +17,7 @@ class PromptMode(Enum):
     MONOT5 = "monot5"
     DUOT5 = "duot5"
     LiT5 = "LiT5"
+    INSERTRANK = "insertrank"
 
     def __str__(self):
         return self.value

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -10,6 +10,7 @@ from rank_llm.rerank import (
     get_openai_api_key,
 )
 from rank_llm.rerank.listwise import RankListwiseOSLLM, SafeGenai, SafeOpenai
+from rank_llm.rerank.listwise.insertrank_reranker import InsertRankReranker
 from rank_llm.rerank.listwise.rank_fid import RankFiDDistill, RankFiDScore
 from rank_llm.rerank.pairwise.duot5 import DuoT5
 from rank_llm.rerank.pointwise.monot5 import MonoT5
@@ -439,6 +440,43 @@ class Reranker:
                 device=device,
             )
             print(f"Completed loading {model_path}")
+        elif kwargs.get("prompt_mode") == PromptMode.INSERTRANK:
+            # InsertRank reranking model
+            print(f"Loading InsertRank with {model_path} ...")
+            
+            keys_and_defaults = [
+                ("context_size", 4096),
+                ("num_few_shot_examples", 0),
+                ("few_shot_file", None),
+                ("device", "cuda"),
+                ("num_gpus", 1),
+                ("variable_passages", False),
+                ("window_size", 20),
+                ("system_message", None),
+            ]
+            [
+                context_size,
+                num_few_shot_examples,
+                few_shot_file,
+                device,
+                num_gpus,
+                variable_passages,
+                window_size,
+                system_message,
+            ] = extract_kwargs(keys_and_defaults, **kwargs)
+
+            model_coordinator = InsertRankReranker(
+                model_path=model_path,
+                context_size=context_size,
+                num_few_shot_examples=num_few_shot_examples,
+                few_shot_file=few_shot_file,
+                device=device,
+                num_gpus=num_gpus,
+                variable_passages=variable_passages,
+                window_size=window_size,
+                system_message=system_message,
+            )
+            print(f"Completed loading InsertRank with {model_path}")
         elif model_path in ["unspecified", "rank_random", "rank_identity"]:
             # NULL reranker
             agent = None


### PR DESCRIPTION
Implements InsertRank approach for LLM-based reranking that integrates BM25 scores as additional context to improve listwise ranking performance. Added Documentation within the code.

## Implementation Details
- Added INSERTRANK prompt mode to support new reranker type
- Created InsertRankReranker class that inherits from RankListwiseOSLLM
- Integrates BM25 scores into prompts following paper format
- Uses listwise reranking approach with BM25 context injection

## Performance Results
- Model: Qwen/Qwen2.5-7B-Instruct
- Standard RankGPT: 0.6007 NDCG@10
- InsertRank: 0.5816 NDCG@10 (97% of baseline performance)

## Command I ran:
```bash
python src/rank_llm/scripts/run_rank_llm.py \
  --model_path=Qwen/Qwen2.5-7B-Instruct \
  --dataset=dl20 \
  --retrieval_method=bm25 \
  --prompt_mode=insertrank \
  --context_size=4096 \
  --num_gpus=1
```

## Reference
Based on "InsertRank: LLMs can reason over BM25 scores to Improve Listwise Reranking" arXiv: https://arxiv.org/abs/2506.14086