### PR TITLE
Add Nemotron-9B-v2 reranker (OpenRouter)

### DIFF
--- a/src/rank_llm/demo/rerank_nvidia_openrouter.py
+++ b/src/rank_llm/demo/rerank_nvidia_openrouter.py
@@ -1,0 +1,78 @@
+"""
+NVIDIA-Nemotron-Nano-9B-v2 reranker using OpenRouter API.
+Based on this OpenRouter integration: 55d5c1f4a49080e92af1b19a184ea57982ae9f8b
+"""
+
+import os
+import sys
+from importlib.resources import files
+from pathlib import Path
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
+
+from rank_llm.data import DataWriter
+from rank_llm.rerank import Reranker, get_openrouter_api_key
+from rank_llm.rerank.listwise import SafeOpenai
+from rank_llm.retrieve import Retriever
+
+# By default uses BM25 for retrieval
+dataset_name = "dl19"
+requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
+TEMPLATES = files("rank_llm.rerank.prompt_templates")
+
+# Test both thinking and non-thinking modes
+model = "nvidia/nemotron-nano-9b-v2:free"
+query_text = requests[0].query.text
+print(f"Testing query: {query_text[:50]}...")
+
+# Test 1: Thinking mode
+try:
+    thinking_coordinator = SafeOpenai(
+        model, 4096, keys=get_openrouter_api_key(),
+        base_url="https://openrouter.ai/api/v1/",
+        prompt_template_path=(TEMPLATES / "nvidia_thinking_template.yaml"),
+    )
+    thinking_reranker = Reranker(thinking_coordinator)
+    print(f"Using {model} with thinking mode")
+    
+    thinking_results = thinking_reranker.rerank_batch(requests[:1], populate_invocations_history=True)
+    
+    # Save thinking results
+    writer = DataWriter(thinking_results)
+    Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
+    writer.write_in_jsonl_format("demo_outputs/nvidia_thinking_results.jsonl")
+    writer.write_in_trec_eval_format("demo_outputs/nvidia_thinking_results.txt")
+    writer.write_inference_invocations_history("demo_outputs/nvidia_thinking_invocations.json")
+    
+    print("Thinking mode results saved")
+    
+except Exception as e:
+    print(f"Thinking mode failed: {e}")
+
+# Test 2: Non-thinking mode
+try:
+    non_thinking_coordinator = SafeOpenai(
+        model, 4096, keys=get_openrouter_api_key(),
+        base_url="https://openrouter.ai/api/v1/",
+        prompt_template_path=(TEMPLATES / "nvidia_non_thinking_template.yaml"),
+    )
+    non_thinking_reranker = Reranker(non_thinking_coordinator)
+    print(f"Using {model} with non-thinking mode")
+    
+    non_thinking_results = non_thinking_reranker.rerank_batch(requests[:1], populate_invocations_history=True)
+    
+    # Save non-thinking results
+    writer = DataWriter(non_thinking_results)
+    writer.write_in_jsonl_format("demo_outputs/nvidia_non_thinking_results.jsonl")
+    writer.write_in_trec_eval_format("demo_outputs/nvidia_non_thinking_results.txt")
+    writer.write_inference_invocations_history("demo_outputs/nvidia_non_thinking_invocations.json")
+    
+    print("Non-thinking mode results saved")
+    
+except Exception as e:
+    print(f"Non-thinking mode failed: {e}")
+
+print("Results saved to demo_outputs/")

--- a/src/rank_llm/rerank/prompt_templates/nvidia_non_thinking_template.yaml
+++ b/src/rank_llm/rerank/prompt_templates/nvidia_non_thinking_template.yaml
@@ -1,0 +1,31 @@
+method: "singleturn_listwise"
+system_message: |
+  /no_think
+  
+  You are RankLLM, an intelligent assistant that can rank passages based on their relevancy to the query.
+  Given a query and a list of passages, your task is to re-rank these passages based on their relevance to the query.
+
+  Please perform the following steps:
+  1. **Understand the Query**: First, carefully read and understand the user's query to identify the core information need.
+  2. **Analyze Each Passage**: For each passage, critically evaluate its content and determine how well it addresses the query. Consider factors like:
+     - Directness of the answer
+     - Completeness of the information
+     - Presence of supporting evidence or details
+     - Absence of irrelevant or distracting information
+  3. **Compare and Contrast**: Compare the passages against each other. Identify which passages are more relevant and why. Note any subtle differences in relevance.
+  4. **Assign Ranks**: Based on your analysis, assign a unique rank to each passage, starting from 1 for the most relevant.
+
+  **Output Format:**
+  Your final output must be a list of ranks, corresponding to the original order of the passages. For example, if there are 3 passages, and you decide the second passage is most relevant, the first is second most relevant, and the third is least relevant, your output should be:
+  [2] > [1] > [3]
+
+  No other text or explanation should be present in the final output, only the list of ranks.
+prefix: |
+  I will provide you with {num} passages, each indicated by a numerical identifier []. Rank the passages based on their relevance to the search query: {query}.
+body: |
+  [{rank}] {candidate}
+suffix: |-
+  Search Query: {query}.
+  Rank the {num} passages above based on their relevance to the search query. All the passages should be included and listed using identifiers, in descending order of relevance. The output format should be [] > [], e.g., [2] > [1], Answer concisely and directly and only respond with the ranking results, do not say any word or explain.
+output_validation_regex: r"^\[\d+\]( > \[\d+\])*$"
+output_extraction_regex: r"\[(\d+)\]"

--- a/src/rank_llm/rerank/prompt_templates/nvidia_thinking_template.yaml
+++ b/src/rank_llm/rerank/prompt_templates/nvidia_thinking_template.yaml
@@ -1,0 +1,32 @@
+method: "singleturn_listwise"
+system_message: |
+  /think
+  
+  You are RankLLM, an intelligent assistant that can rank passages based on their relevancy to the query.
+  Given a query and a list of passages, your task is to re-rank these passages based on their relevance to the query.
+
+  Please perform the following steps:
+  1. **Understand the Query**: First, carefully read and understand the user's query to identify the core information need.
+  2. **Analyze Each Passage**: For each passage, critically evaluate its content and determine how well it addresses the query. Consider factors like:
+     - Directness of the answer
+     - Completeness of the information
+     - Presence of supporting evidence or details
+     - Absence of irrelevant or distracting information
+  3. **Compare and Contrast**: Compare the passages against each other. Identify which passages are more relevant and why. Note any subtle differences in relevance.
+  4. **Reasoning for Ranking**: Explicitly state your reasoning for the rank you assign to each passage. Explain why a passage is ranked higher or lower than others. This step-by-step thought process is crucial.
+  5. **Assign Ranks**: Based on your analysis and reasoning, assign a unique rank to each passage, starting from 1 for the most relevant.
+
+  **Output Format:**
+  Your final output must be a list of ranks, corresponding to the original order of the passages. For example, if there are 3 passages, and you decide the second passage is most relevant, the first is second most relevant, and the third is least relevant, your output should be:
+  [2] > [1] > [3]
+
+  No other text or explanation should be present in the final output, only the list of ranks.
+prefix: |
+  I will provide you with {num} passages, each indicated by a numerical identifier []. Rank the passages based on their relevance to the search query: {query}.
+body: |
+  [{rank}] {candidate}
+suffix: |-
+  Search Query: {query}.
+  Rank the {num} passages above based on their relevance to the search query. All the passages should be included and listed using identifiers, in descending order of relevance. The output format should be [] > [], e.g., [2] > [1], Answer concisely and directly and only respond with the ranking results, do not say any word or explain.
+output_validation_regex: r"^\[\d+\]( > \[\d+\])*$"
+output_extraction_regex: r"\[(\d+)\]"


### PR DESCRIPTION
# Pull Request: Add Nemotron-9B-v2 reranker integration (OpenRouter)

## Description

- Prompt templates for thinking / non-thinking  
- Demo via OpenRouter API (no vLLM)  
- Intended as a temporary integration for experimenting

Addresses #298  

## Reference Issue

ref: #298  

## Checklist Items

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [ ] Have you updated any relevant documentation or added new tests where needed?

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: N/A

## Testing

Run the demo script to verify Nemotron reranking:

```bash
python demo/nemotron_reranker.py