### PR TITLE
feat(rerank): add rerank_async for stream-style concurrent reranking

### DIFF
--- a/src/rank_llm/demo/rerank_oss_bright_async.py
+++ b/src/rank_llm/demo/rerank_oss_bright_async.py
@@ -1,0 +1,126 @@
+"""
+BRIGHT reranking demo using OpenAI-compatible vLLM (gpt-oss-20b) with **async** API.
+
+Same inputs and outputs as ``rerank_oss_bright.py``, but each topic's requests are
+reranked with ``await reranker.rerank_async(...)`` per request (via ``asyncio.gather``),
+not ``rerank_batch``. That overlaps HTTP calls to the vLLM server while respecting the
+listwise per-instance concurrency cap.
+
+Requires the same vLLM server as ``rerank_oss_bright.py`` (see note below). Build the
+``Reranker`` **before** ``asyncio.run`` so tokenizer / client init stays off the async loop.
+
+Note: You need to run the vllm server with the following command:
+```bash
+RANK_MODEL_ID="openai/gpt-oss-20b"
+RANK_PORT=48003
+RANK_VLLM_LOG="vllm_server_48003.log"
+CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID"  \
+ --port "$RANK_PORT" \
+ --dtype auto \
+ --gpu-memory-utilization 0.9 \
+ --max-model-len 32768 \
+ --enable-prompt-tokens-details \
+ --enable-prefix-caching \
+ > "$RANK_VLLM_LOG" 2>&1 &
+```
+"""
+
+import asyncio
+import json
+import os
+import sys
+from importlib.resources import files
+from pathlib import Path
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
+
+from rank_llm.data import DataWriter, Request, Result, read_requests_from_file
+from rank_llm.evaluation.trec_eval import EvalFunction
+from rank_llm.rerank import Reranker
+from rank_llm.rerank.listwise import RankListwiseOSLLM
+
+TEMPLATES = files("rank_llm.rerank.prompt_templates")
+
+
+def build_reranker() -> Reranker:
+    return Reranker(
+        RankListwiseOSLLM(
+            context_size=4096 * 4,
+            model="openai/gpt-oss-20b",
+            use_alpha=True,
+            is_thinking=True,
+            reasoning_token_budget=4096 * 4,
+            base_url="http://localhost:48003/v1",
+            prompt_template_path=(TEMPLATES / "rank_zephyr_template.yaml"),
+        )
+    )
+
+
+async def rerank_requests_async(
+    reranker: Reranker,
+    requests: list[Request],
+    **kwargs,
+) -> list[Result]:
+    """One ``rerank_async`` per request; all share one event loop and reranker instance."""
+    return await asyncio.gather(
+        *(reranker.rerank_async(req, **kwargs) for req in requests)
+    )
+
+
+async def async_main(reranker: Reranker) -> None:
+    """One event loop for the whole run so the shared listwise semaphore stays valid."""
+    kwargs = {"populate_invocations_history": True}
+
+    for fusion in ["bm25-splade", "bge-splade", "bm25-bge"]:
+        for task in [
+            "aops",
+            "biology",
+            "earth-science",
+            "economics",
+            "leetcode",
+            "pony",
+            "psychology",
+            "robotics",
+            "stackoverflow",
+            "sustainable-living",
+            "theoremqa-questions",
+            "theoremqa-theorems",
+        ]:
+            file_name = f"../bright_fusion/retrieve_results/retrieve_results_bright-{task}-rrf-{fusion}_top100.jsonl"
+            retrieve_results = read_requests_from_file(file_name)
+            qrels = f"../bright_fusion/qrels/qrels.bright-{task}.txt"
+            retrieve_ndcg_10 = EvalFunction.from_results(retrieve_results, qrels)
+
+            rerank_results = await rerank_requests_async(
+                reranker, retrieve_results, **kwargs
+            )
+
+            rerank_ndcg_10 = EvalFunction.from_results(rerank_results, qrels)
+            writer = DataWriter(rerank_results)
+            path = Path("../bright_fusion/rerank_results/gpt-oss-20b-async")
+            path.mkdir(parents=True, exist_ok=True)
+            writer.write_in_jsonl_format(
+                os.path.join(path, f"{task}-rrf-{fusion}_top100.jsonl")
+            )
+            writer.write_in_trec_eval_format(
+                os.path.join(path, f"{task}-rrf-{fusion}_top100.txt")
+            )
+            writer.write_inference_invocations_history(
+                os.path.join(path, f"{task}-rrf-{fusion}_top100_invocations.json")
+            )
+            with open(
+                os.path.join(path, f"{task}-rrf-{fusion}_top100_metrics.json"), "w"
+            ) as f:
+                json.dump({"retrieve": retrieve_ndcg_10, "rerank": rerank_ndcg_10}, f)
+
+
+def main() -> None:
+    reranker = build_reranker()
+    asyncio.run(async_main(reranker))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_qwen_async.py
+++ b/src/rank_llm/demo/rerank_qwen_async.py
@@ -1,0 +1,91 @@
+"""
+Concurrent async reranking demo (Qwen + vLLM).
+
+Uses multiple ``await reranker.rerank_async(...)`` calls on one event loop and one
+``Reranker`` instance so sliding-window LLM work overlaps across queries.
+
+Requires the same runtime setup as ``rerank_qwen.py`` (local vLLM with the model loaded).
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
+
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+import multiprocessing as mp
+
+try:
+    mp.set_start_method("spawn")
+except RuntimeError:
+    pass
+
+from rank_llm.analysis.response_analysis import ResponseAnalyzer
+from rank_llm.data import DataWriter, Request
+from rank_llm.evaluation.trec_eval import EvalFunction
+from rank_llm.rerank import Reranker
+from rank_llm.rerank.listwise import RankListwiseOSLLM
+from rank_llm.retrieve import Retriever
+from rank_llm.retrieve.topics_dict import TOPICS
+
+# Limit how many queries run concurrently for a faster smoke test; set to None for all.
+NUM_ASYNC_REQUESTS: int | None = 16
+
+
+async def rerank_requests_concurrently(
+    reranker: Reranker,
+    requests: list[Request],
+    **kwargs,
+):
+    """Rerank each request with ``rerank_async``; all tasks share the same event loop and reranker."""
+    return await asyncio.gather(
+        *(reranker.rerank_async(req, **kwargs) for req in requests)
+    )
+
+
+async def async_main():
+    dataset_name = "dl19"
+    requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
+    if NUM_ASYNC_REQUESTS is not None:
+        requests = requests[:NUM_ASYNC_REQUESTS]
+
+    model_coordinator = RankListwiseOSLLM(
+        model="Qwen/Qwen2.5-7B-Instruct",
+    )
+    reranker = Reranker(model_coordinator)
+    kwargs = {"populate_invocations_history": True}
+
+    rerank_results = await rerank_requests_concurrently(reranker, requests, **kwargs)
+
+    analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=False)
+    error_counts = analyzer.count_errors()
+    print(error_counts.__repr__())
+
+    topics = TOPICS[dataset_name]
+    rerank_ndcg_10 = EvalFunction.from_results(rerank_results, topics)
+    print(rerank_ndcg_10)
+
+    writer = DataWriter(rerank_results)
+    Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
+    writer.write_in_jsonl_format(
+        "demo_outputs/rerank_results_qwen2.5-7b-instruct_async.jsonl"
+    )
+    writer.write_in_trec_eval_format(
+        "demo_outputs/rerank_results_qwen2.5-7b-instruct_async.txt"
+    )
+    writer.write_inference_invocations_history(
+        "demo_outputs/inference_invocations_history_qwen2.5-7b-instruct_async.json"
+    )
+
+
+def main():
+    asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_qwen_async.py
+++ b/src/rank_llm/demo/rerank_qwen_async.py
@@ -1,5 +1,5 @@
 """
-Concurrent async reranking demo (Qwen + vLLM).
+Concurrent async reranking demo (Qwen3.5 9B + vLLM).
 
 Uses multiple ``await reranker.rerank_async(...)`` calls on one event loop and one
 ``Reranker`` instance so sliding-window LLM work overlaps across queries.
@@ -8,7 +8,8 @@ The reranker is constructed **before** ``asyncio.run`` (sync setup); only the ga
 runs under the event loop, matching the one-loop contract and avoiding nested
 ``asyncio.run`` during model init.
 
-Requires the same runtime setup as ``rerank_qwen.py`` (local vLLM with the model loaded).
+Requires local vLLM with ``Qwen/Qwen3.5-9B`` loaded (same general setup as ``rerank_qwen.py``,
+but serve this model id).
 """
 
 import asyncio
@@ -61,7 +62,7 @@ def load_requests(dataset_name: str) -> list[Request]:
 
 def build_reranker() -> Reranker:
     model_coordinator = RankListwiseOSLLM(
-        model="Qwen/Qwen2.5-7B-Instruct",
+        model="Qwen/Qwen3.5-9B",
     )
     return Reranker(model_coordinator)
 
@@ -92,14 +93,10 @@ def main():
 
     writer = DataWriter(rerank_results)
     Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-    writer.write_in_jsonl_format(
-        "demo_outputs/rerank_results_qwen2.5-7b-instruct_async.jsonl"
-    )
-    writer.write_in_trec_eval_format(
-        "demo_outputs/rerank_results_qwen2.5-7b-instruct_async.txt"
-    )
+    writer.write_in_jsonl_format("demo_outputs/rerank_results_qwen3.5-9b_async.jsonl")
+    writer.write_in_trec_eval_format("demo_outputs/rerank_results_qwen3.5-9b_async.txt")
     writer.write_inference_invocations_history(
-        "demo_outputs/inference_invocations_history_qwen2.5-7b-instruct_async.json"
+        "demo_outputs/inference_invocations_history_qwen3.5-9b_async.json"
     )
 
 

--- a/src/rank_llm/demo/rerank_qwen_async.py
+++ b/src/rank_llm/demo/rerank_qwen_async.py
@@ -1,13 +1,8 @@
 """
 Concurrent async reranking demo (Qwen + vLLM).
 
-Uses multiple concurrent ``rerank_async`` calls on one event loop and one loaded
-listwise model so sliding-window LLM work overlaps across queries.
-
-The demo keeps a ``Reranker`` wrapper for parity with ``rerank_qwen.py``; async work
-is dispatched via ``Reranker.rerank_async`` when present, otherwise
-``reranker._model_coordinator.rerank_async`` (for trees where ``Reranker`` has not
-yet gained async methods).
+Uses multiple ``await reranker.rerank_async(...)`` calls on one event loop and one
+``Reranker`` instance so sliding-window LLM work overlaps across queries.
 
 The reranker is constructed **before** ``asyncio.run`` (sync setup); only the gather phase
 runs under the event loop, matching the one-loop contract and avoiding nested
@@ -46,21 +41,14 @@ from rank_llm.retrieve.topics_dict import TOPICS
 NUM_ASYNC_REQUESTS: int | None = 16
 
 
-async def _rerank_one_async(reranker: Reranker, req: Request, **kwargs):
-    """Prefer ``Reranker.rerank_async``; fall back to the coordinator (older installs)."""
-    if hasattr(reranker, "rerank_async"):
-        return await reranker.rerank_async(req, **kwargs)
-    return await reranker._model_coordinator.rerank_async(req, **kwargs)
-
-
 async def rerank_requests_concurrently(
     reranker: Reranker,
     requests: list[Request],
     **kwargs,
 ):
-    """Rerank each request concurrently; all tasks share the same event loop and model instance."""
+    """Rerank each request with ``rerank_async``; all tasks share the same event loop and reranker."""
     return await asyncio.gather(
-        *(_rerank_one_async(reranker, req, **kwargs) for req in requests)
+        *(reranker.rerank_async(req, **kwargs) for req in requests)
     )
 
 

--- a/src/rank_llm/demo/rerank_qwen_async.py
+++ b/src/rank_llm/demo/rerank_qwen_async.py
@@ -1,8 +1,13 @@
 """
 Concurrent async reranking demo (Qwen + vLLM).
 
-Uses multiple ``await reranker.rerank_async(...)`` calls on one event loop and one
-``Reranker`` instance so sliding-window LLM work overlaps across queries.
+Uses multiple concurrent ``rerank_async`` calls on one event loop and one loaded
+listwise model so sliding-window LLM work overlaps across queries.
+
+The demo keeps a ``Reranker`` wrapper for parity with ``rerank_qwen.py``; async work
+is dispatched via ``Reranker.rerank_async`` when present, otherwise
+``reranker._model_coordinator.rerank_async`` (for trees where ``Reranker`` has not
+yet gained async methods).
 
 The reranker is constructed **before** ``asyncio.run`` (sync setup); only the gather phase
 runs under the event loop, matching the one-loop contract and avoiding nested
@@ -41,14 +46,21 @@ from rank_llm.retrieve.topics_dict import TOPICS
 NUM_ASYNC_REQUESTS: int | None = 16
 
 
+async def _rerank_one_async(reranker: Reranker, req: Request, **kwargs):
+    """Prefer ``Reranker.rerank_async``; fall back to the coordinator (older installs)."""
+    if hasattr(reranker, "rerank_async"):
+        return await reranker.rerank_async(req, **kwargs)
+    return await reranker._model_coordinator.rerank_async(req, **kwargs)
+
+
 async def rerank_requests_concurrently(
     reranker: Reranker,
     requests: list[Request],
     **kwargs,
 ):
-    """Rerank each request with ``rerank_async``; all tasks share the same event loop and reranker."""
+    """Rerank each request concurrently; all tasks share the same event loop and model instance."""
     return await asyncio.gather(
-        *(reranker.rerank_async(req, **kwargs) for req in requests)
+        *(_rerank_one_async(reranker, req, **kwargs) for req in requests)
     )
 
 

--- a/src/rank_llm/demo/rerank_qwen_async.py
+++ b/src/rank_llm/demo/rerank_qwen_async.py
@@ -4,6 +4,10 @@ Concurrent async reranking demo (Qwen + vLLM).
 Uses multiple ``await reranker.rerank_async(...)`` calls on one event loop and one
 ``Reranker`` instance so sliding-window LLM work overlaps across queries.
 
+The reranker is constructed **before** ``asyncio.run`` (sync setup); only the gather phase
+runs under the event loop, matching the one-loop contract and avoiding nested
+``asyncio.run`` during model init.
+
 Requires the same runtime setup as ``rerank_qwen.py`` (local vLLM with the model loaded).
 """
 
@@ -48,19 +52,35 @@ async def rerank_requests_concurrently(
     )
 
 
-async def async_main():
-    dataset_name = "dl19"
+def load_requests(dataset_name: str) -> list[Request]:
     requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
     if NUM_ASYNC_REQUESTS is not None:
-        requests = requests[:NUM_ASYNC_REQUESTS]
+        return requests[:NUM_ASYNC_REQUESTS]
+    return requests
 
+
+def build_reranker() -> Reranker:
     model_coordinator = RankListwiseOSLLM(
         model="Qwen/Qwen2.5-7B-Instruct",
     )
-    reranker = Reranker(model_coordinator)
+    return Reranker(model_coordinator)
+
+
+async def async_rerank_phase(
+    reranker: Reranker,
+    requests: list[Request],
+    **kwargs,
+):
+    return await rerank_requests_concurrently(reranker, requests, **kwargs)
+
+
+def main():
+    dataset_name = "dl19"
+    requests = load_requests(dataset_name)
+    reranker = build_reranker()
     kwargs = {"populate_invocations_history": True}
 
-    rerank_results = await rerank_requests_concurrently(reranker, requests, **kwargs)
+    rerank_results = asyncio.run(async_rerank_phase(reranker, requests, **kwargs))
 
     analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=False)
     error_counts = analyzer.count_errors()
@@ -81,10 +101,6 @@ async def async_main():
     writer.write_inference_invocations_history(
         "demo_outputs/inference_invocations_history_qwen2.5-7b-instruct_async.json"
     )
-
-
-def main():
-    asyncio.run(async_main())
 
 
 if __name__ == "__main__":

--- a/src/rank_llm/demo/rerank_qwen_async.py
+++ b/src/rank_llm/demo/rerank_qwen_async.py
@@ -37,8 +37,8 @@ from rank_llm.rerank.listwise import RankListwiseOSLLM
 from rank_llm.retrieve import Retriever
 from rank_llm.retrieve.topics_dict import TOPICS
 
-# Limit how many queries run concurrently for a faster smoke test; set to None for all.
-NUM_ASYNC_REQUESTS: int | None = 16
+# Set to an int (e.g. 8) to cap topics for a quick smoke test; None = all requests like rerank_qwen.py.
+NUM_ASYNC_REQUESTS: int | None = None
 
 
 async def rerank_requests_concurrently(

--- a/src/rank_llm/rerank/identity_reranker.py
+++ b/src/rank_llm/rerank/identity_reranker.py
@@ -44,6 +44,25 @@ class IdentityReranker:
             results.append(rerank_result)
         return results
 
+    def rerank(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        results = self.rerank_batch(
+            requests=[request],
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+        return results[0]
+
     async def rerank_batch_async(
         self,
         requests: list[Request],

--- a/src/rank_llm/rerank/identity_reranker.py
+++ b/src/rank_llm/rerank/identity_reranker.py
@@ -44,6 +44,42 @@ class IdentityReranker:
             results.append(rerank_result)
         return results
 
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return self.rerank_batch(
+            requests,
+            rank_start,
+            rank_end,
+            shuffle_candidates,
+            logging,
+            **kwargs,
+        )
+
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        return self.rerank(
+            request,
+            rank_start,
+            rank_end,
+            shuffle_candidates,
+            logging,
+            **kwargs,
+        )
+
     def get_name(self) -> str:
         return "identity_reranker"
 

--- a/src/rank_llm/rerank/listwise/listwise_rankllm.py
+++ b/src/rank_llm/rerank/listwise/listwise_rankllm.py
@@ -63,10 +63,15 @@ class ListwiseRankLLM(RankLLM, ABC):
         self._stride = stride
         self._max_passage_words = max_passage_words
         # Shared across concurrent rerank_batch_async / rerank_async calls on one instance.
+        # Requires one process, one long-lived event loop, and one reranker instance (see rerank_async).
         self._llm_concurrency_sem: asyncio.Semaphore | None = None
 
     def _get_llm_concurrency_sem(self) -> asyncio.Semaphore:
-        """Semaphore limiting in-flight LLM calls across overlapping async rerank operations."""
+        """Semaphore limiting in-flight LLM calls across overlapping async rerank operations.
+
+        The semaphore is tied to the event loop in which it is first created; reuse the same
+        reranker only under that loop (see ``rerank_async``).
+        """
         if self._llm_concurrency_sem is None:
             self._llm_concurrency_sem = asyncio.Semaphore(max(self._batch_size, 1))
         return self._llm_concurrency_sem
@@ -454,7 +459,13 @@ class ListwiseRankLLM(RankLLM, ABC):
         isolate_llm_slots: bool = False,
         **kwargs: Any,
     ) -> list[Result]:
-        """Async sliding-window rerank; overlapping calls share this instance's LLM slot cap."""
+        """Async sliding-window rerank; overlapping calls share this instance's LLM slot cap.
+
+        Contract: use **one process**, **one long-lived asyncio event loop**, and **one
+        reranker instance** for concurrent ``rerank_batch_async`` / ``rerank_async`` calls.
+        Do not reuse the same instance across separate ``asyncio.run()`` invocations or
+        different loops; the shared semaphore is bound to the loop where it was created.
+        """
         top_k_retrieve: int = kwargs.get("top_k_retrieve", rank_end)
         rank_end_adj = min(top_k_retrieve, rank_end)
         populate_invocations_history: bool = kwargs.get(
@@ -482,7 +493,10 @@ class ListwiseRankLLM(RankLLM, ABC):
         isolate_llm_slots: bool = False,
         **kwargs: Any,
     ) -> Result:
-        """Rerank one request; overlaps with other rerank_async on the same instance."""
+        """Rerank one request; overlaps with other rerank_async on the same instance.
+
+        Same usage contract as :meth:`rerank_batch_async` (one process, one loop, one instance).
+        """
         results = await self.rerank_batch_async(
             [request],
             rank_start=rank_start,

--- a/src/rank_llm/rerank/listwise/listwise_rankllm.py
+++ b/src/rank_llm/rerank/listwise/listwise_rankllm.py
@@ -315,14 +315,13 @@ class ListwiseRankLLM(RankLLM, ABC):
         populate_invocations_history: bool = False,
         *,
         isolate_llm_slots: bool = False,
-        concurrency_sem: asyncio.Semaphore | None = None,
     ) -> list[Result]:
         """
         Async sliding-window rerank for one or more requests.
 
         isolate_llm_slots: if True, use a fresh semaphore for this invocation only (legacy
-        sync rerank_batch behavior). If False, share capacity with other concurrent async
-        reranks via concurrency_sem or the instance-level limiter.
+        sync rerank_batch behavior). If False, use this instance's shared semaphore so
+        overlapping rerank_async / rerank_batch_async calls share the same in-flight cap.
         """
         stride = self._stride
         window_size = min(self._window_size, top_k_retrieve)
@@ -355,8 +354,6 @@ class ListwiseRankLLM(RankLLM, ABC):
 
         if isolate_llm_slots:
             semaphore = asyncio.Semaphore(max(self._batch_size, 1))
-        elif concurrency_sem is not None:
-            semaphore = concurrency_sem
         else:
             semaphore = self._get_llm_concurrency_sem()
 
@@ -455,10 +452,9 @@ class ListwiseRankLLM(RankLLM, ABC):
         logging: bool = False,
         *,
         isolate_llm_slots: bool = False,
-        llm_concurrency_sem: asyncio.Semaphore | None = None,
         **kwargs: Any,
     ) -> list[Result]:
-        """Async sliding-window rerank; overlapping calls share LLM concurrency by default."""
+        """Async sliding-window rerank; overlapping calls share this instance's LLM slot cap."""
         top_k_retrieve: int = kwargs.get("top_k_retrieve", rank_end)
         rank_end_adj = min(top_k_retrieve, rank_end)
         populate_invocations_history: bool = kwargs.get(
@@ -473,7 +469,6 @@ class ListwiseRankLLM(RankLLM, ABC):
             logging=logging,
             populate_invocations_history=populate_invocations_history,
             isolate_llm_slots=isolate_llm_slots,
-            concurrency_sem=llm_concurrency_sem,
         )
 
     async def rerank_async(
@@ -485,10 +480,9 @@ class ListwiseRankLLM(RankLLM, ABC):
         logging: bool = False,
         *,
         isolate_llm_slots: bool = False,
-        llm_concurrency_sem: asyncio.Semaphore | None = None,
         **kwargs: Any,
     ) -> Result:
-        """Rerank one request without batching many queries; overlaps with other rerank_async calls."""
+        """Rerank one request; overlaps with other rerank_async on the same instance."""
         results = await self.rerank_batch_async(
             [request],
             rank_start=rank_start,
@@ -496,7 +490,6 @@ class ListwiseRankLLM(RankLLM, ABC):
             shuffle_candidates=shuffle_candidates,
             logging=logging,
             isolate_llm_slots=isolate_llm_slots,
-            llm_concurrency_sem=llm_concurrency_sem,
             **kwargs,
         )
         return results[0]

--- a/src/rank_llm/rerank/listwise/listwise_rankllm.py
+++ b/src/rank_llm/rerank/listwise/listwise_rankllm.py
@@ -62,6 +62,14 @@ class ListwiseRankLLM(RankLLM, ABC):
         self._batch_size = batch_size
         self._stride = stride
         self._max_passage_words = max_passage_words
+        # Shared across concurrent rerank_batch_async / rerank_async calls on one instance.
+        self._llm_concurrency_sem: asyncio.Semaphore | None = None
+
+    def _get_llm_concurrency_sem(self) -> asyncio.Semaphore:
+        """Semaphore limiting in-flight LLM calls across overlapping async rerank operations."""
+        if self._llm_concurrency_sem is None:
+            self._llm_concurrency_sem = asyncio.Semaphore(max(self._batch_size, 1))
+        return self._llm_concurrency_sem
 
     def get_output_filename(
         self,
@@ -296,6 +304,104 @@ class ListwiseRankLLM(RankLLM, ABC):
             start_pos = max(start_pos, rank_start)
         return count
 
+    async def _sliding_windows_batched_async(
+        self,
+        requests: list[Request],
+        rank_start: int,
+        rank_end: int,
+        top_k_retrieve: int,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        populate_invocations_history: bool = False,
+        *,
+        isolate_llm_slots: bool = False,
+        concurrency_sem: asyncio.Semaphore | None = None,
+    ) -> list[Result]:
+        """
+        Async sliding-window rerank for one or more requests.
+
+        isolate_llm_slots: if True, use a fresh semaphore for this invocation only (legacy
+        sync rerank_batch behavior). If False, share capacity with other concurrent async
+        reranks via concurrency_sem or the instance-level limiter.
+        """
+        stride = self._stride
+        window_size = min(self._window_size, top_k_retrieve)
+
+        rerank_results = [
+            Result(
+                query=copy.deepcopy(request.query),
+                candidates=copy.deepcopy(request.candidates),
+                invocations_history=[],
+            )
+            for request in requests
+        ]
+        if shuffle_candidates:
+            self.shuffle_and_rescore(rerank_results, rank_start, rank_end)
+
+        work_queue: deque = deque()
+        for idx in range(len(rerank_results)):
+            end_pos = min(rank_end, len(rerank_results[idx].candidates))
+            start_pos = max(end_pos - window_size, rank_start)
+            if end_pos > start_pos:
+                work_queue.append((idx, start_pos, end_pos))
+
+        total_work = sum(
+            self._count_windows(
+                len(r.candidates), rank_start, rank_end, window_size, stride
+            )
+            for r in rerank_results
+        )
+        progress = tqdm(total=total_work, desc="Sliding windows")
+
+        if isolate_llm_slots:
+            semaphore = asyncio.Semaphore(max(self._batch_size, 1))
+        elif concurrency_sem is not None:
+            semaphore = concurrency_sem
+        else:
+            semaphore = self._get_llm_concurrency_sem()
+
+        pending_tasks: set = set()
+
+        async def _process_one(idx: int, s: int, e: int) -> None:
+            async with semaphore:
+                prompt, in_tok = self.create_prompt(rerank_results[idx], s, e)
+                if logging:
+                    logger.debug(f"[req {idx}] window [{s}, {e}] prompt: {prompt}\n")
+                llm_out = await self.run_llm_async(prompt, e - s)
+                rerank_results[idx] = self._apply_llm_output_to_result(
+                    rerank_results[idx],
+                    llm_out,
+                    prompt,
+                    in_tok,
+                    s,
+                    e,
+                    logging,
+                    populate_invocations_history,
+                )
+                progress.update(1)
+
+                next_end = e - stride
+                next_start = s - stride
+                next_start = max(next_start, rank_start)
+                if next_end > next_start and s != rank_start:
+                    task = asyncio.ensure_future(
+                        _process_one(idx, next_start, next_end)
+                    )
+                    pending_tasks.add(task)
+                    task.add_done_callback(pending_tasks.discard)
+
+        async def _run_all() -> None:
+            for idx, s, e in work_queue:
+                task = asyncio.ensure_future(_process_one(idx, s, e))
+                pending_tasks.add(task)
+                task.add_done_callback(pending_tasks.discard)
+            while pending_tasks:
+                await asyncio.wait(list(pending_tasks))
+
+        await _run_all()
+        progress.close()
+        return rerank_results
+
     def sliding_windows_batched(
         self,
         requests: list[Request],
@@ -325,90 +431,75 @@ class ListwiseRankLLM(RankLLM, ABC):
         Returns:
             List[Result]: The list of result objects after applying the sliding window technique.
         """
-        stride = self._stride
-        window_size = min(self._window_size, top_k_retrieve)
 
-        rerank_results = [
-            Result(
-                query=copy.deepcopy(request.query),
-                candidates=copy.deepcopy(request.candidates),
-                invocations_history=[],
+        async def _run() -> list[Result]:
+            return await self._sliding_windows_batched_async(
+                requests,
+                rank_start,
+                rank_end,
+                top_k_retrieve,
+                shuffle_candidates,
+                logging,
+                populate_invocations_history,
+                isolate_llm_slots=True,
             )
-            for request in requests
-        ]
-        if shuffle_candidates:
-            self.shuffle_and_rescore(rerank_results, rank_start, rank_end)
 
-        # Each work item is (result_idx, start_pos, end_pos).
-        # Initialise with the first (rightmost) window for every request.
-        work_queue: deque = deque()
-        for idx in range(len(rerank_results)):
-            end_pos = min(rank_end, len(rerank_results[idx].candidates))
-            start_pos = max(end_pos - window_size, rank_start)
-            # Mirror the original loop condition before clamping start_pos.
-            if end_pos > start_pos:
-                work_queue.append((idx, start_pos, end_pos))
+        return asyncio.run(_run())
 
-        total_work = sum(
-            self._count_windows(
-                len(r.candidates), rank_start, rank_end, window_size, stride
-            )
-            for r in rerank_results
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        *,
+        isolate_llm_slots: bool = False,
+        llm_concurrency_sem: asyncio.Semaphore | None = None,
+        **kwargs: Any,
+    ) -> list[Result]:
+        """Async sliding-window rerank; overlapping calls share LLM concurrency by default."""
+        top_k_retrieve: int = kwargs.get("top_k_retrieve", rank_end)
+        rank_end_adj = min(top_k_retrieve, rank_end)
+        populate_invocations_history: bool = kwargs.get(
+            "populate_invocations_history", False
         )
-        progress = tqdm(total=total_work, desc="Sliding windows")
+        return await self._sliding_windows_batched_async(
+            requests,
+            rank_start=max(rank_start, 0),
+            rank_end=rank_end_adj,
+            top_k_retrieve=top_k_retrieve,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            populate_invocations_history=populate_invocations_history,
+            isolate_llm_slots=isolate_llm_slots,
+            concurrency_sem=llm_concurrency_sem,
+        )
 
-        # Semaphore caps the number of concurrently in-flight LLM requests.
-        # Each coroutine handles one (request, window) pair end-to-end:
-        # create prompt → await LLM → apply permutation → enqueue next window.
-        # Because all coroutines are gathered concurrently, the async LLM
-        # backend (AsyncLLMEngine / AsyncOpenAI) sees all requests at once and
-        # schedules them with continuous batching — no waiting for stragglers.
-        semaphore = asyncio.Semaphore(self._batch_size)
-        pending_tasks: set = set()
-
-        async def _process_one(idx: int, s: int, e: int) -> None:
-            async with semaphore:
-                prompt, in_tok = self.create_prompt(rerank_results[idx], s, e)
-                if logging:
-                    logger.debug(f"[req {idx}] window [{s}, {e}] prompt: {prompt}\n")
-                llm_out = await self.run_llm_async(prompt, e - s)
-                rerank_results[idx] = self._apply_llm_output_to_result(
-                    rerank_results[idx],
-                    llm_out,
-                    prompt,
-                    in_tok,
-                    s,
-                    e,
-                    logging,
-                    populate_invocations_history,
-                )
-                progress.update(1)
-
-                # Immediately spawn the next window for this request so it
-                # can run concurrently with all other in-flight windows.
-                next_end = e - stride
-                next_start = s - stride
-                next_start = max(next_start, rank_start)
-                if next_end > next_start and s != rank_start:
-                    task = asyncio.ensure_future(
-                        _process_one(idx, next_start, next_end)
-                    )
-                    pending_tasks.add(task)
-                    task.add_done_callback(pending_tasks.discard)
-
-        async def _run_all() -> None:
-            # Seed: one task per request for its first window.
-            for idx, s, e in work_queue:
-                task = asyncio.ensure_future(_process_one(idx, s, e))
-                pending_tasks.add(task)
-                task.add_done_callback(pending_tasks.discard)
-            # Wait until every task (including dynamically spawned ones) is done.
-            while pending_tasks:
-                await asyncio.wait(list(pending_tasks))
-
-        asyncio.run(_run_all())
-        progress.close()
-        return rerank_results
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        *,
+        isolate_llm_slots: bool = False,
+        llm_concurrency_sem: asyncio.Semaphore | None = None,
+        **kwargs: Any,
+    ) -> Result:
+        """Rerank one request without batching many queries; overlaps with other rerank_async calls."""
+        results = await self.rerank_batch_async(
+            [request],
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            isolate_llm_slots=isolate_llm_slots,
+            llm_concurrency_sem=llm_concurrency_sem,
+            **kwargs,
+        )
+        return results[0]
 
     def sliding_windows(
         self,

--- a/src/rank_llm/rerank/listwise/lit5_reranker.py
+++ b/src/rank_llm/rerank/listwise/lit5_reranker.py
@@ -73,6 +73,42 @@ class LiT5DistillReranker:
             **kwargs,
         )
 
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await self._reranker.rerank_batch_async(
+            requests=requests,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        return await self._reranker.rerank_async(
+            request=request,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
     def rerank(
         self,
         request: Request,
@@ -164,6 +200,42 @@ class LiT5ScoreReranker:
         """
         return self._reranker.rerank_batch(
             requests=requests,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await self._reranker.rerank_batch_async(
+            requests=requests,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        return await self._reranker.rerank_async(
+            request=request,
             rank_start=rank_start,
             rank_end=rank_end,
             shuffle_candidates=shuffle_candidates,

--- a/src/rank_llm/rerank/listwise/rank_fid.py
+++ b/src/rank_llm/rerank/listwise/rank_fid.py
@@ -1,3 +1,4 @@
+import asyncio
 from importlib.resources import files
 from typing import Any
 
@@ -147,6 +148,25 @@ class RankFiDDistill(ListwiseRankLLM):
                 bar.update(len(batch))
 
         return result
+
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await asyncio.to_thread(
+            self.rerank_batch,
+            requests,
+            rank_start,
+            rank_end,
+            shuffle_candidates,
+            logging,
+            **kwargs,
+        )
 
     def run_llm_batched(
         self, prompts: list[list[dict[str, str]]], **kwargs
@@ -393,6 +413,25 @@ class RankFiDScore(ListwiseRankLLM):
                 bar.update(len(batch))
 
         return result
+
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await asyncio.to_thread(
+            self.rerank_batch,
+            requests,
+            rank_start,
+            rank_end,
+            shuffle_candidates,
+            logging,
+            **kwargs,
+        )
 
     def run_llm_batched(
         self, prompts: list[list[dict[str, str]]], **kwargs

--- a/src/rank_llm/rerank/listwise/rank_gpt.py
+++ b/src/rank_llm/rerank/listwise/rank_gpt.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from importlib.resources import files
@@ -204,6 +205,25 @@ class SafeOpenai(ListwiseRankLLM):
                 progress.close()
 
         return [results[index] for index in range(len(requests))]
+
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await asyncio.to_thread(
+            self.rerank_batch,
+            requests,
+            rank_start,
+            rank_end,
+            shuffle_candidates,
+            logging,
+            **kwargs,
+        )
 
     def _call_completion(
         self,

--- a/src/rank_llm/rerank/listwise/vicuna_reranker.py
+++ b/src/rank_llm/rerank/listwise/vicuna_reranker.py
@@ -79,6 +79,42 @@ class VicunaReranker:
             **kwargs,
         )
 
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await self._reranker.rerank_batch_async(
+            requests=requests,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        return await self._reranker.rerank_async(
+            request=request,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
     def rerank(
         self,
         request: Request,

--- a/src/rank_llm/rerank/listwise/zephyr_reranker.py
+++ b/src/rank_llm/rerank/listwise/zephyr_reranker.py
@@ -77,6 +77,42 @@ class ZephyrReranker:
             **kwargs,
         )
 
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await self._reranker.rerank_batch_async(
+            requests=requests,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        return await self._reranker.rerank_async(
+            request=request,
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+
     def rerank(
         self,
         request: Request,

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -199,6 +200,46 @@ class RankLLM(ABC):
             List[Result]: A list containing the reranked candidates.
         """
         pass
+
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        """Async wrapper for backends without a native async path (runs sync rerank in a thread)."""
+        return await asyncio.to_thread(
+            self.rerank_batch,
+            requests,
+            rank_start,
+            rank_end,
+            shuffle_candidates,
+            logging,
+            **kwargs,
+        )
+
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        """Async single-request rerank; implementations may override for cross-call concurrency."""
+        results = await self.rerank_batch_async(
+            [request],
+            rank_start=rank_start,
+            rank_end=rank_end,
+            shuffle_candidates=shuffle_candidates,
+            logging=logging,
+            **kwargs,
+        )
+        return results[0]
 
     @abstractmethod
     def get_output_filename(

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -210,7 +210,12 @@ class RankLLM(ABC):
         logging: bool = False,
         **kwargs: Any,
     ) -> list[Result]:
-        """Async wrapper for backends without a native async path (runs sync rerank in a thread)."""
+        """Async wrapper for backends without a native async path (runs sync rerank in a thread).
+
+        Listwise subclasses that override this share an LLM concurrency limit per instance;
+        for those, follow the contract documented on ``ListwiseRankLLM.rerank_batch_async``
+        (one process, one long-lived event loop, one reranker instance).
+        """
         return await asyncio.to_thread(
             self.rerank_batch,
             requests,
@@ -230,7 +235,10 @@ class RankLLM(ABC):
         logging: bool = False,
         **kwargs: Any,
     ) -> Result:
-        """Async single-request rerank; implementations may override for cross-call concurrency."""
+        """Async single-request rerank; implementations may override for cross-call concurrency.
+
+        Listwise implementations document loop/instance constraints on ``rerank_batch_async``.
+        """
         results = await self.rerank_batch_async(
             [request],
             rank_start=rank_start,

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -59,6 +59,7 @@ class Reranker:
         logging: bool = False,
         **kwargs: Any,
     ) -> list[Result]:
+        """Delegates to the coordinator; listwise coordinators expect one process, one loop, one instance."""
         return await self._model_coordinator.rerank_batch_async(
             requests, rank_start, rank_end, shuffle_candidates, logging, **kwargs
         )
@@ -72,6 +73,7 @@ class Reranker:
         logging: bool = False,
         **kwargs: Any,
     ) -> Result:
+        """Delegates to the coordinator; listwise coordinators expect one process, one loop, one instance."""
         return await self._model_coordinator.rerank_async(
             request, rank_start, rank_end, shuffle_candidates, logging, **kwargs
         )

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -50,6 +50,32 @@ class Reranker:
             requests, rank_start, rank_end, shuffle_candidates, logging, **kwargs
         )
 
+    async def rerank_batch_async(
+        self,
+        requests: list[Request],
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> list[Result]:
+        return await self._model_coordinator.rerank_batch_async(
+            requests, rank_start, rank_end, shuffle_candidates, logging, **kwargs
+        )
+
+    async def rerank_async(
+        self,
+        request: Request,
+        rank_start: int = 0,
+        rank_end: int = 100,
+        shuffle_candidates: bool = False,
+        logging: bool = False,
+        **kwargs: Any,
+    ) -> Result:
+        return await self._model_coordinator.rerank_async(
+            request, rank_start, rank_end, shuffle_candidates, logging, **kwargs
+        )
+
     def rerank(
         self,
         request: Request,

--- a/src/rank_llm/rerank/vllm_handler.py
+++ b/src/rank_llm/rerank/vllm_handler.py
@@ -8,6 +8,11 @@ try:
 except ImportError:
     vllm = None
 
+try:
+    from transformers import AutoTokenizer
+except ImportError:
+    AutoTokenizer = None
+
 if TYPE_CHECKING:
     from transformers import PreTrainedTokenizerBase
 else:
@@ -57,7 +62,22 @@ class VllmHandler:
 
     def get_tokenizer(self) -> PreTrainedTokenizerBase:
         if self._tokenizer is None:
-            self._tokenizer = asyncio.run(self._engine.get_tokenizer())
+            try:
+                asyncio.get_running_loop()
+                in_running_loop = True
+            except RuntimeError:
+                in_running_loop = False
+            if in_running_loop:
+                # asyncio.run() is invalid here; load the same weights the engine uses.
+                if AutoTokenizer is None:
+                    raise ImportError(
+                        "Tokenizer loading inside a running event loop requires transformers."
+                    )
+                self._tokenizer = AutoTokenizer.from_pretrained(
+                    self._model, trust_remote_code=True
+                )
+            else:
+                self._tokenizer = asyncio.run(self._engine.get_tokenizer())
             if "rank_vicuna" in self._model:
                 self._tokenizer.chat_template = """{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}\n                    {% for message in messages %}{% if not loop.first %}{% endif %}{% if message['role'] == 'system' %}{{ message['content'] + ' ' }}{% elif message['role'] == 'user' %}{{ 'USER: ' + message['content'] + ' ' }}{% elif message['role'] == 'assistant' %}{{ 'ASSISTANT: ' + message['content'] + '</s>' }}{% endif %}{% endfor %}{% if add_generation_prompt %}{{ 'ASSISTANT:' }}{% endif %}"""
         return self._tokenizer

--- a/src/rank_llm/rerank/vllm_handler_with_openai_sdk.py
+++ b/src/rank_llm/rerank/vllm_handler_with_openai_sdk.py
@@ -24,6 +24,11 @@ class VllmHandlerWithOpenAISDK:
     Uses AsyncOpenAI for inference so all concurrently submitted coroutines
     are in-flight simultaneously. The sync OpenAI client is kept only for the
     one-time model discovery call at init time.
+
+    Unlike :class:`~rank_llm.rerank.vllm_handler.VllmHandler`, the tokenizer is
+    loaded synchronously in ``__init__`` (no ``asyncio.run``). It is therefore
+    safe to construct this handler while an asyncio event loop is already
+    running (e.g. building ``RankListwiseOSLLM`` from inside an async task).
     """
 
     def __init__(
@@ -43,9 +48,12 @@ class VllmHandlerWithOpenAISDK:
             model = models.data[0].id
 
         self._model = model
-        self._tokenizer = AutoTokenizer.from_pretrained(model)
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            model, trust_remote_code=True
+        )
 
     def get_tokenizer(self) -> PreTrainedTokenizerBase:
+        """Return the tokenizer loaded in ``__init__`` (always sync, loop-safe)."""
         return self._tokenizer
 
     async def chat_completion_async(

--- a/src/rank_llm/rerank/vllm_handler_with_openai_sdk.py
+++ b/src/rank_llm/rerank/vllm_handler_with_openai_sdk.py
@@ -48,9 +48,7 @@ class VllmHandlerWithOpenAISDK:
             model = models.data[0].id
 
         self._model = model
-        self._tokenizer = AutoTokenizer.from_pretrained(
-            model, trust_remote_code=True
-        )
+        self._tokenizer = AutoTokenizer.from_pretrained(model, trust_remote_code=True)
 
     def get_tokenizer(self) -> PreTrainedTokenizerBase:
         """Return the tokenizer loaded in ``__init__`` (always sync, loop-safe)."""

--- a/test/rerank/listwise/test_rerank_async.py
+++ b/test/rerank/listwise/test_rerank_async.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from dacite import from_dict
 
-from rank_llm.data import Request, Result
+from rank_llm.data import Request
 from rank_llm.rerank.listwise.rank_listwise_os_llm import RankListwiseOSLLM
 
 
@@ -35,8 +35,9 @@ class TestRerankAsyncSharedConcurrency(unittest.IsolatedAsyncioTestCase):
     async def test_concurrent_rerank_async_shares_semaphore(self):
         with (
             patch("rank_llm.utils.default_device", return_value="cuda"),
-            patch("rank_llm.rerank.listwise.rank_listwise_os_llm.torch", new=MagicMock())
-            as mock_torch,
+            patch(
+                "rank_llm.rerank.listwise.rank_listwise_os_llm.torch", new=MagicMock()
+            ) as mock_torch,
         ):
             mock_torch.cuda.is_available.return_value = True
             mock_torch.cuda.device_count.return_value = 1
@@ -48,9 +49,7 @@ class TestRerankAsyncSharedConcurrency(unittest.IsolatedAsyncioTestCase):
                         "rank_llm.rerank.vllm_handler_with_openai_sdk.VllmHandlerWithOpenAISDK"
                     ) as oa:
                         mock_tok = MagicMock()
-                        mock_tok.apply_chat_template.side_effect = (
-                            lambda m, **k: str(m)
-                        )
+                        mock_tok.apply_chat_template.side_effect = lambda m, **k: str(m)
                         mock_tok.encode.side_effect = lambda x, **k: [0] * 4
                         vh.return_value.get_tokenizer.return_value = mock_tok
                         oa.return_value.get_tokenizer.return_value = mock_tok

--- a/test/rerank/listwise/test_rerank_async.py
+++ b/test/rerank/listwise/test_rerank_async.py
@@ -61,8 +61,6 @@ class TestRerankAsyncSharedConcurrency(unittest.IsolatedAsyncioTestCase):
                             stride=1,
                             batch_size=1,
                         )
-        _shared_sem = asyncio.Semaphore(1)
-        m._get_llm_concurrency_sem = lambda: _shared_sem  # type: ignore[method-assign]
         m.create_prompt = MagicMock(  # type: ignore[method-assign]
             return_value=("[p]", 1)
         )

--- a/test/rerank/listwise/test_rerank_async.py
+++ b/test/rerank/listwise/test_rerank_async.py
@@ -1,0 +1,95 @@
+import asyncio
+import unittest
+from unittest.mock import MagicMock, patch
+
+from dacite import from_dict
+
+from rank_llm.data import Request, Result
+from rank_llm.rerank.listwise.rank_listwise_os_llm import RankListwiseOSLLM
+
+
+def _minimal_request() -> Request:
+    return from_dict(
+        data_class=Request,
+        data={
+            "query": {"text": "q", "qid": "q1"},
+            "candidates": [
+                {
+                    "doc": {"contents": "a"},
+                    "docid": "d1",
+                    "score": 0.5,
+                },
+                {
+                    "doc": {"contents": "b"},
+                    "docid": "d2",
+                    "score": 0.4,
+                },
+            ],
+        },
+    )
+
+
+class TestRerankAsyncSharedConcurrency(unittest.IsolatedAsyncioTestCase):
+    """Concurrent rerank_async calls share one LLM slot cap (listwise + vLLM path)."""
+
+    async def test_concurrent_rerank_async_shares_semaphore(self):
+        with (
+            patch("rank_llm.utils.default_device", return_value="cuda"),
+            patch("rank_llm.rerank.listwise.rank_listwise_os_llm.torch", new=MagicMock())
+            as mock_torch,
+        ):
+            mock_torch.cuda.is_available.return_value = True
+            mock_torch.cuda.device_count.return_value = 1
+            with patch(
+                "rank_llm.rerank.listwise.rank_listwise_os_llm.vllm", new=MagicMock()
+            ):
+                with patch("rank_llm.rerank.vllm_handler.VllmHandler") as vh:
+                    with patch(
+                        "rank_llm.rerank.vllm_handler_with_openai_sdk.VllmHandlerWithOpenAISDK"
+                    ) as oa:
+                        mock_tok = MagicMock()
+                        mock_tok.apply_chat_template.side_effect = (
+                            lambda m, **k: str(m)
+                        )
+                        mock_tok.encode.side_effect = lambda x, **k: [0] * 4
+                        vh.return_value.get_tokenizer.return_value = mock_tok
+                        oa.return_value.get_tokenizer.return_value = mock_tok
+                        m = RankListwiseOSLLM(
+                            model="m",
+                            context_size=256,
+                            window_size=2,
+                            stride=1,
+                            batch_size=1,
+                        )
+        _shared_sem = asyncio.Semaphore(1)
+        m._get_llm_concurrency_sem = lambda: _shared_sem  # type: ignore[method-assign]
+        m.create_prompt = MagicMock(  # type: ignore[method-assign]
+            return_value=("[p]", 1)
+        )
+        m.receive_permutation = MagicMock(side_effect=lambda res, *_a, **_k: res)  # type: ignore[method-assign]
+        in_flight = 0
+        max_in_flight = 0
+        leave_order: list[str] = []
+
+        async def slow_llm(*_a, **_k):
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            await asyncio.sleep(0.05)
+            in_flight -= 1
+            return "1 2", "", {"prompt_tokens": 1, "completion_tokens": 1}
+
+        m.run_llm_async = slow_llm  # type: ignore[method-assign]
+
+        async def trace(tag: str):
+            _ = await m.rerank_async(_minimal_request(), rank_end=2)
+            leave_order.append(tag)
+
+        await asyncio.gather(trace("a"), trace("b"))
+
+        self.assertEqual(max_in_flight, 1)
+        self.assertEqual(leave_order, ["a", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/rerank/test_VllmHandler.py
+++ b/test/rerank/test_VllmHandler.py
@@ -53,6 +53,24 @@ class TestVllmHandler(unittest.TestCase):
         self.handler.get_tokenizer()
         self.mock_engine_instance.get_tokenizer.assert_awaited_once()
 
+    def test_get_tokenizer_inside_running_loop_uses_autotokenizer(self):
+        """When no loop is running, engine path is used; inside a loop, AutoTokenizer is used."""
+        mock_tok = MagicMock(name="from_pretrained_tok")
+        mock_auto = MagicMock()
+        mock_auto.from_pretrained.return_value = mock_tok
+
+        async def inner() -> None:
+            self.handler._tokenizer = None
+            with patch.object(vllm_handler_module, "AutoTokenizer", mock_auto):
+                out = self.handler.get_tokenizer()
+            self.assertIs(out, mock_tok)
+            mock_auto.from_pretrained.assert_called_once_with(
+                "test-model", trust_remote_code=True
+            )
+            self.mock_engine_instance.get_tokenizer.assert_not_called()
+
+        asyncio.run(inner())
+
     def test_generate_output_async(self):
         mock_request_output = MagicMock()
         mock_request_output.finished = True

--- a/test/rerank/test_VllmHandlerWithOpenAISDK.py
+++ b/test/rerank/test_VllmHandlerWithOpenAISDK.py
@@ -10,6 +10,7 @@ class TestVllmHandlerWithOpenAISDK(unittest.TestCase):
     @patch("rank_llm.rerank.vllm_handler_with_openai_sdk.OpenAI")
     @patch("rank_llm.rerank.vllm_handler_with_openai_sdk.AutoTokenizer")
     def setUp(self, mock_tokenizer_class, mock_openai_class, mock_async_openai_class):
+        self.mock_tokenizer_class = mock_tokenizer_class
         self.mock_sync_client = mock_openai_class.return_value
         self.mock_async_client = mock_async_openai_class.return_value
         self.mock_tokenizer = mock_tokenizer_class.from_pretrained.return_value
@@ -25,6 +26,9 @@ class TestVllmHandlerWithOpenAISDK(unittest.TestCase):
     def test_init(self):
         self.assertEqual(self.handler._model, "test-model")
         self.assertEqual(self.handler._tokenizer, self.mock_tokenizer)
+        self.mock_tokenizer_class.from_pretrained.assert_called_once_with(
+            "test-model", trust_remote_code=True
+        )
 
     def test_get_tokenizer(self):
         self.assertEqual(self.handler.get_tokenizer(), self.mock_tokenizer)

--- a/test/rerank/test_identity_reranker.py
+++ b/test/rerank/test_identity_reranker.py
@@ -1,0 +1,28 @@
+import unittest
+
+from dacite import from_dict
+
+from rank_llm.data import Request
+from rank_llm.rerank.identity_reranker import IdentityReranker
+
+
+class TestIdentityReranker(unittest.TestCase):
+    def test_rerank_matches_first_of_batch(self):
+        req = from_dict(
+            data_class=Request,
+            data={
+                "query": {"text": "q", "qid": 1},
+                "candidates": [
+                    {"docid": "a", "score": 0.9, "doc": {"contents": "x"}},
+                ],
+            },
+        )
+        ir = IdentityReranker()
+        one = ir.rerank(req, rank_end=1)
+        many = ir.rerank_batch([req], rank_end=1)
+        self.assertEqual(one.query.text, many[0].query.text)
+        self.assertEqual(len(one.candidates), len(many[0].candidates))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Reference Issue

N/A

## Summary

- Add `async def rerank_async` and `async def rerank_batch_async` on `ListwiseRankLLM` so callers can overlap work with multiple concurrent `await rerank_async(...)` on the **same** instance without manually batching requests.
- Per-instance `asyncio.Semaphore` (`batch_size`) caps in-flight sliding-window LLM calls across overlapping async reranks. Sync `sliding_windows_batched` keeps **per-invocation** isolation via `isolate_llm_slots`.
- Optional **`llm_concurrency_sem`** / external semaphore injection was removed; concurrency is **only** per reranker instance as requested.
- Default implementations on `RankLLM`: `rerank_async` / `rerank_batch_async` use `asyncio.to_thread(rerank_batch)` where appropriate; `SafeOpenai` and RankFiD classes override.

## Why

Streaming single-query reranks could not overlap LLM work across calls when each sync `rerank_batch` owned its own budget.
For applications like deep search when queries are fired one at a time, allowing multiple concurrent requests per each reranker enables use of vllm batching/concurrency. Without this feature, micro batching on the caller side was required to avoid handling one rerank request at a time.

## Validation

```bash
pip install -e .
PYTHONPATH=src python3 -m unittest discover test/rerank -v
```
The two added async demos are confirmed to run after testing the PR locally.

## Follow-ups

- Document for async servers: one event loop, reuse one reranker instance, `asyncio.gather` multiple `rerank_async` tasks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7bf1aecc-18e1-48a8-9dc5-f71b7e6cf875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bf1aecc-18e1-48a8-9dc5-f71b7e6cf875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

