### PR TITLE
Parameterize three more demos

### DIFF
--- a/src/rank_llm/demo/rerank_duot5.py
+++ b/src/rank_llm/demo/rerank_duot5.py
@@ -1,3 +1,29 @@
+"""
+Pairwise reranking demo with DuoT5 (e.g. ``castorini/duot5-3b-msmarco-10k``)
+on top of BM25 first-stage retrieval from a Pyserini prebuilt index.
+
+DuoT5 is a T5 encoder-decoder pairwise reranker: for every pair of
+candidates (d_i, d_j) it predicts whether d_i is more relevant than d_j
+to the query, and an aggregation over those pairwise scores produces the
+final ranking. The number of forward passes therefore grows quadratically
+in k, so smaller k is recommended than for pointwise demos.
+
+Prerequisites:
+  pip install -e '.[pyserini,local]'
+
+Usage (from repo root):
+  python src/rank_llm/demo/rerank_duot5.py
+  python src/rank_llm/demo/rerank_duot5.py \\
+      --dataset dl19 \\
+      --model castorini/duot5-base-msmarco \\
+      --batch-size 16 \\
+      --device cpu \\
+      --num-queries 5
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -7,24 +33,138 @@ parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
-from rank_llm.data import DataWriter
+from rank_llm.data import DataWriter, Result
+from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker
 from rank_llm.rerank.pairwise.duot5 import DuoT5
+from rank_llm.retrieve import TOPICS
 from rank_llm.retrieve.retriever import Retriever
 
-dataset = "dl20"
-requests = Retriever.from_dataset_with_prebuilt_index(dataset, k=50)
-duot5_model_coordinator = DuoT5("castorini/duot5-3b-msmarco-10k")
-m_reranker = Reranker(duot5_model_coordinator)
-kwargs = {"populate_invocations_history": True}
-rerank_results = m_reranker.rerank_batch(requests, **kwargs)
-print(rerank_results)
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-# write rerank results
-writer = DataWriter(rerank_results)
-Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-writer.write_in_jsonl_format("demo_outputs/rerank_results.jsonl")
-writer.write_in_trec_eval_format("demo_outputs/rerank_results.txt")
-writer.write_inference_invocations_history(
-    "demo_outputs/inference_invocations_history.json"
-)
+
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Pairwise DuoT5 reranking on BM25 first-stage results."
+    )
+    p.add_argument(
+        "--dataset",
+        default="dl20",
+        help="TREC dataset name with a Pyserini prebuilt index (default: dl20).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=50,
+        help="Top-k passages per query from first-stage retrieval (default: 50; "
+        "pairwise scoring is quadratic in k).",
+    )
+    p.add_argument(
+        "--model",
+        default="castorini/duot5-3b-msmarco-10k",
+        help="HuggingFace model id for DuoT5 (default: castorini/duot5-3b-msmarco-10k).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Per-step batch size for the pairwise scorer (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=512,
+        help="Context size for the model (default: 512, matches DuoT5 default).",
+    )
+    p.add_argument(
+        "--device",
+        default="cuda",
+        help="Torch device to run the model on (default: cuda; use 'cpu' on machines without a GPU).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    args = p.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    coordinator = DuoT5(
+        model=args.model,
+        context_size=args.context_size,
+        device=args.device,
+        batch_size=args.batch_size,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {"populate_invocations_history": True}
+
+    print(f"\n--- Batched reranking ({len(requests)} queries) ---")
+    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    print(f"Reranked {len(rerank_results)} results.")
+    _print_sample(rerank_results)
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
+
+    # --- Save outputs ---
+    model_tag = args.model.split("/")[-1].lower()
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_lit5.py
+++ b/src/rank_llm/demo/rerank_lit5.py
@@ -1,3 +1,34 @@
+"""
+Listwise reranking demo with LiT5 (e.g. ``castorini/LiT5-Distill-large`` and
+``castorini/LiT5-Score-large``) on top of BM25 first-stage retrieval from a
+Pyserini prebuilt index.
+
+LiT5 is a Fusion-in-Decoder listwise reranker family with two variants:
+  - **Distill**: encodes each (query, candidate) independently in the encoder
+    then decodes a permutation over the candidates inside one window.
+  - **Score**: same FiD encoder backbone but emits a per-candidate relevance
+    score instead of a permutation. Useful when you want absolute scores or
+    when downstream callers expect a calibrated value per document.
+
+Like other listwise rerankers it uses a sliding window over the candidate
+list (default window=20, stride=10).
+
+Prerequisites:
+  pip install -e '.[pyserini,local]'
+
+Usage (from repo root):
+  python src/rank_llm/demo/rerank_lit5.py
+  python src/rank_llm/demo/rerank_lit5.py \\
+      --variant distill \\
+      --distill-model castorini/LiT5-Distill-base \\
+      --dataset dl20 \\
+      --device cpu \\
+      --num-queries 5
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -7,37 +38,195 @@ parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
-from rank_llm.data import DataWriter
-from rank_llm.rerank import Reranker
+from rank_llm.data import DataWriter, Result
+from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank.listwise.lit5_reranker import (
     LiT5DistillReranker,
     LiT5ScoreReranker,
 )
+from rank_llm.retrieve import TOPICS
 from rank_llm.retrieve.retriever import Retriever
 
-dataset = "dl19"
-requests = Retriever.from_dataset_with_prebuilt_index(dataset, k=100)
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-# Rerank multiple requests with LiT5 Distill
-lit5_d_model_coordinator = LiT5DistillReranker("castorini/LiT5-Distill-large")
-lit5_d_reranker = Reranker(lit5_d_model_coordinator)
-kwargs = {"populate_invocations_history": True}
-rerank_results = lit5_d_reranker.rerank_batch(requests, **kwargs)
-print(rerank_results)
 
-# Rerank a single request with LiT5 Score
-request = requests[0]
-lit5_s_model_coordinator = LiT5ScoreReranker("castorini/LiT5-Score-large")
-lit5_s_reranker = Reranker(lit5_s_model_coordinator)
-kwargs = {"populate_invocations_history": True}
-rerank_result = lit5_s_reranker.rerank(request, **kwargs)
-print(rerank_results)
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
 
-# write rerank results
-writer = DataWriter(rerank_results)
-Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-writer.write_in_jsonl_format("demo_outputs/rerank_results.jsonl")
-writer.write_in_trec_eval_format("demo_outputs/rerank_results.txt")
-writer.write_inference_invocations_history(
-    "demo_outputs/inference_invocations_history.json"
-)
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise LiT5 reranking on BM25 first-stage results."
+    )
+    p.add_argument(
+        "--variant",
+        choices=("both", "distill", "score"),
+        default="both",
+        help="Which LiT5 variant to run (default: both — Distill across the "
+        "full request set then a single-query Score demo, matching the "
+        "original hardcoded script).",
+    )
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with a Pyserini prebuilt index (default: dl19).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--distill-model",
+        default="castorini/LiT5-Distill-large",
+        help="HuggingFace model id for LiT5-Distill (default: castorini/LiT5-Distill-large).",
+    )
+    p.add_argument(
+        "--score-model",
+        default="castorini/LiT5-Score-large",
+        help="HuggingFace model id for LiT5-Score (default: castorini/LiT5-Score-large).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Per-step batch size for the FiD scorer (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=300,
+        help="Context size for the model (default: 300, matches LiT5 default).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--precision",
+        default="bfloat16",
+        help="Numerical precision for LiT5-Distill (default: bfloat16).",
+    )
+    p.add_argument(
+        "--device",
+        default="cuda",
+        help="Torch device to run the model on (default: cuda; use 'cpu' on machines without a GPU).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    args = p.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    rerank_results: list[Result] = []
+    run_distill = args.variant in ("both", "distill")
+    run_score = args.variant in ("both", "score")
+
+    if run_distill:
+        distill = LiT5DistillReranker(
+            model_path=args.distill_model,
+            context_size=args.context_size,
+            precision=args.precision,
+            window_size=args.window_size,
+            stride=args.stride,
+            device=args.device,
+            batch_size=args.batch_size,
+        )
+        kwargs = {"populate_invocations_history": True}
+        print(f"\n--- LiT5-Distill batched reranking ({len(requests)} queries) ---")
+        rerank_results = distill.rerank_batch(requests, **kwargs)
+        print(f"Reranked {len(rerank_results)} results.")
+        _print_sample(rerank_results)
+
+        if qrels and run_eval:
+            print(f"\n{'=' * 60}")
+            print(f"Reranking metrics  ({args.distill_model})")
+            print(f"{'=' * 60}")
+            _print_eval(rerank_results, qrels)
+
+    if run_score:
+        score = LiT5ScoreReranker(
+            model_path=args.score_model,
+            context_size=args.context_size,
+            window_size=args.window_size,
+            stride=args.stride,
+            device=args.device,
+            batch_size=args.batch_size,
+        )
+        request = requests[0]
+        print(f"\n--- LiT5-Score single-query demo (qid={request.query.qid}) ---")
+        score_results = score.rerank_batch([request], populate_invocations_history=True)
+        score_result = score_results[0]
+        print(f"qid={score_result.query.qid} text={score_result.query.text!r}")
+        for c in score_result.candidates[:5]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+        if not rerank_results:
+            rerank_results = score_results
+
+    # --- Save outputs ---
+    primary_model = args.distill_model if run_distill else args.score_model
+    model_tag = primary_model.split("/")[-1].lower()
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_rank_gpt.py
+++ b/src/rank_llm/demo/rerank_rank_gpt.py
@@ -1,40 +1,206 @@
+"""
+Listwise reranking demo with RankGPT (OpenAI chat models such as
+``gpt-4o-mini``) on top of BM25 first-stage retrieval from a Pyserini
+prebuilt index.
+
+RankGPT is the original sliding-window listwise prompting approach: the
+prompt instructs the model to output a permutation of the candidate list
+inside a window, and the window slides backwards across the full candidate
+set with a configurable overlap. Per-query cost scales with the number of
+windows and the model's price-per-token, so smaller k and tighter strides
+keep the demo cheap.
+
+Prerequisites:
+  pip install -e '.[pyserini]'
+
+The OpenAI API key is loaded via ``rank_llm.rerank.get_openai_api_key``
+(reads ``OPENAI_API_KEY`` / ``OPEN_AI_API_KEY`` env vars or a ``.env.local``
+file at the repo root).
+
+Usage (from repo root):
+  python src/rank_llm/demo/rerank_rank_gpt.py
+  python src/rank_llm/demo/rerank_rank_gpt.py \\
+      --dataset dl20 \\
+      --model gpt-4o-mini \\
+      --num-queries 5 \\
+      --skip-eval
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
 import sys
 from importlib.resources import files
+from pathlib import Path
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
+from rank_llm.data import DataWriter, Result
+from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker, get_openai_api_key
 from rank_llm.rerank.listwise import SafeOpenai
-from rank_llm.retrieve import Retriever
+from rank_llm.retrieve import TOPICS, Retriever
 
-# By default uses BM25 for retrieval
-dataset_name = "dl19"
-requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
 TEMPLATES = files("rank_llm.rerank.prompt_templates")
-model_coordinator = SafeOpenai(
-    "gpt-4o-mini",
-    4096,
-    keys=get_openai_api_key(),
-    prompt_template_path=(TEMPLATES / "rank_gpt_template.yaml"),
-)
-reranker = Reranker(model_coordinator)
-kwargs = {"populate_invocations_history": True}
-rerank_results = reranker.rerank_batch(requests, **kwargs)
-print(rerank_results)
 
-from pathlib import Path
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-from rank_llm.data import DataWriter
 
-# write rerank results
-writer = DataWriter(rerank_results)
-Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-writer.write_in_jsonl_format("demo_outputs/rerank_results.jsonl")
-writer.write_in_trec_eval_format("demo_outputs/rerank_results.txt")
-writer.write_inference_invocations_history(
-    "demo_outputs/inference_invocations_history.json"
-)
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise RankGPT reranking on BM25 first-stage results."
+    )
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with a Pyserini prebuilt index (default: dl19).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--model",
+        default="gpt-4o-mini",
+        help="OpenAI chat model id (default: gpt-4o-mini).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size budgeted per window (default: 4096).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Per-step batch size (default: 32).",
+    )
+    p.add_argument(
+        "--prompt-template",
+        default=None,
+        help="Override prompt template path (default: bundled rank_gpt_template.yaml).",
+    )
+    p.add_argument(
+        "--reasoning-effort",
+        default=None,
+        help="Reasoning effort for o-series models (e.g. 'low', 'medium', 'high').",
+    )
+    p.add_argument(
+        "--base-url",
+        default=None,
+        help="Alternate base URL (e.g. for OpenRouter-style OpenAI-compatible providers).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    args = p.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    prompt_template_path = args.prompt_template or str(
+        TEMPLATES / "rank_gpt_template.yaml"
+    )
+    coordinator = SafeOpenai(
+        model=args.model,
+        context_size=args.context_size,
+        keys=get_openai_api_key(),
+        prompt_template_path=prompt_template_path,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        reasoning_effort=args.reasoning_effort,
+        base_url=args.base_url,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {"populate_invocations_history": True}
+
+    print(f"\n--- Batched reranking ({len(requests)} queries) ---")
+    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    print(f"Reranked {len(rerank_results)} results.")
+    _print_sample(rerank_results)
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
+
+    # --- Save outputs ---
+    model_tag = args.model.replace("/", "-").lower()
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
ref: #390

  Parameterize three more demo scripts to match the `rerank_qwen_local.py`
  argparse style established by #393:
  - `rerank_duot5.py` — pairwise DuoT5 (default dl20, 3B model)
  - `rerank_lit5.py` — listwise LiT5 (`--variant {both,distill,score}` keeps original "Distill batched + Score single-query" default)
  - `rerank_rank_gpt.py` — listwise via OpenAI (default gpt-4o-mini)

  ## Validation
  Pre-commit clean for all three. `--help` exits 0 with all flags wired.

  End-to-end on the lab GPU (RTX 4090):

  **duot5 (full dl20, 3B model):**
  nDCG@10    0.6452
  MAP@100    0.3291
  Recall@20  0.3043
  Recall@100 0.3911   (= BM25 baseline; reranking preserves top-100
  membership)
  Lines up with published DuoT5-3b on dl20.

  **lit5 Distill (full dl19, large):**
  nDCG@10    0.7210
  MAP@100    0.3614
  Recall@20  0.2650
  Recall@100 0.4531
  Lines up with published LiT5-Distill-large on dl19.
  
  The LiT5-Score variant currently hits a pre-existing torch ≥ 2.6
  constraint (`LiT5ScoreReranker` uses `torch.load` on a non-safetensors
  checkpoint; torch 2.5 refuses). Not a regression from this PR — the
  original hardcoded lit5 demo would hit the same error on the same torch.
  Flagging as a follow-up (either bump rank_llm's torch floor or convert the
   checkpoint to safetensors).

  **rank_gpt:** `--help` only. Skipped full sweep because it would consume
  OpenAI tokens; happy to run a small sweep on request before merge if
  anyone wants the numbers in the PR description.