### PR TITLE
Issue 248: optimized the DeprecationWarning

### DIFF
--- a/src/rank_llm/rerank/listwise/rank_gemini.py
+++ b/src/rank_llm/rerank/listwise/rank_gemini.py
@@ -1,5 +1,4 @@
 import time
-from importlib.resources import files
 from typing import Any
 
 from tqdm import tqdm
@@ -32,9 +31,6 @@ def populate_generation_config(**kwargs) -> dict[str, Any]:
     return generation_config
 
 
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
-
-
 class SafeGenai(ListwiseRankLLM):
     def __init__(
         self,
@@ -52,15 +48,6 @@ class SafeGenai(ListwiseRankLLM):
         max_passage_words: int = 300,
         **kwargs,
     ):
-        if not prompt_template_path:
-            if prompt_mode == PromptMode.RANK_GPT_APEER:
-                prompt_template_path = TEMPLATES / "rank_gpt_apeer_template.yaml"
-            elif prompt_mode == PromptMode.RANK_GPT:
-                prompt_template_path = TEMPLATES / "rank_zephyr_template.yaml"
-            else:
-                raise ValueError(
-                    "Either `prompt_mode` or `prompt_template_path` must be specified."
-                )
         super().__init__(
             model=model,
             context_size=context_size,
@@ -82,13 +69,6 @@ class SafeGenai(ListwiseRankLLM):
             keys = [keys]
         if not keys:
             raise ValueError("Please provide Genai API Keys.")
-        if prompt_mode and prompt_mode not in [
-            PromptMode.RANK_GPT_APEER,
-            PromptMode.RANK_GPT,
-        ]:
-            raise ValueError(
-                f"unsupported prompt mode for GEMINI models: {prompt_mode}, expected {PromptMode.RANK_GPT_APEER} or {PromptMode.RANK_GPT}."
-            )
         self._output_token_estimate = None
         self._keys = keys
         self._cur_key_id = key_start_id or 0

--- a/src/rank_llm/rerank/listwise/rank_gpt.py
+++ b/src/rank_llm/rerank/listwise/rank_gpt.py
@@ -1,7 +1,6 @@
 import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from importlib.resources import files
 from typing import Any
 
 from tqdm import tqdm
@@ -21,8 +20,6 @@ try:
     import tiktoken
 except ImportError:
     tiktoken = None
-
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
 
 
 class SafeOpenai(ListwiseRankLLM):
@@ -54,8 +51,8 @@ class SafeOpenai(ListwiseRankLLM):
         Parameters:
         - model (str): The model identifier for the LLM (model identifier information can be found via OpenAI's model lists).
         - context_size (int): The maximum number of tokens that the model can handle in a single request.
-        - prompt_mode (PromptMode, optional): Specifies the mode of prompt generation, with the default set to RANK_GPT,
-         indicating that this class is designed primarily for listwise ranking tasks following the RANK_GPT methodology.
+        - prompt_mode (PromptMode, optional): Deprecated and ignored. Prompt behavior is driven by the YAML
+         template at prompt_template_path; passing prompt_mode only emits a deprecation warning.
         - num_few_shot_examples (int, optional): Number of few-shot learning examples to include in the prompt, allowing for
         the integration of example-based learning to improve model performance. Defaults to 0, indicating no few-shot examples
         by default.
@@ -70,7 +67,7 @@ class SafeOpenai(ListwiseRankLLM):
         - api_version (str, optional): The API version, necessary for Azure AI integration.
 
         Raises:
-        - ValueError: If an unsupported prompt mode is provided or if no OpenAI API keys / invalid OpenAI API keys are supplied.
+        - ValueError: If no prompt_template_path is provided or if no OpenAI API keys / invalid OpenAI API keys are supplied.
 
         Note:
         - This class supports cycling between multiple OpenAI API keys to distribute quota usage or handle rate limiting.
@@ -86,26 +83,6 @@ class SafeOpenai(ListwiseRankLLM):
         if not keys:
             raise ValueError("Please provide OpenAI Keys.")
 
-        if prompt_mode and prompt_mode not in [
-            PromptMode.RANK_GPT,
-            PromptMode.RANK_GPT_APEER,
-            PromptMode.LRL,
-        ]:
-            raise ValueError(
-                f"unsupported prompt mode for GPT models: {prompt_mode}, expected {PromptMode.RANK_GPT}, {PromptMode.RANK_GPT_APEER} or {PromptMode.LRL}."
-            )
-
-        if prompt_template_path is None:
-            if prompt_mode == PromptMode.RANK_GPT:
-                prompt_template_path = TEMPLATES / "rank_gpt_template.yaml"
-            elif prompt_mode == PromptMode.RANK_GPT_APEER:
-                prompt_template_path = TEMPLATES / "rank_gpt_apeer_template.yaml"
-            elif prompt_mode == PromptMode.LRL:
-                prompt_template_path = TEMPLATES / "rank_lrl_template.yaml"
-            else:
-                raise ValueError(
-                    "Either `prompt_mode` or `prompt_template_path` must be specified."
-                )
         super().__init__(
             model=model,
             context_size=context_size,

--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -80,8 +80,8 @@ class RankListwiseOSLLM(ListwiseRankLLM):
          Parameters:
          - model (str): Identifier for the language model to be used for ranking tasks.
          - context_size (int, optional): Maximum number of tokens that can be handled in a single prompt. Defaults to 4096.
-         - prompt_mode (PromptMode, optional): Specifies the mode of prompt generation, with the default set to RANK_GPT,
-         indicating that this class is designed primarily for listwise ranking tasks following the RANK_GPT methodology.
+         - prompt_mode (PromptMode, optional): Deprecated and ignored. Prompt behavior is driven by the YAML
+         template at prompt_template_path; passing prompt_mode only emits a deprecation warning.
          - num_few_shot_examples (int, optional): Number of few-shot learning examples to include in the prompt, allowing for
          the integration of example-based learning to improve model performance. Defaults to 0, indicating no few-shot examples
          by default.
@@ -102,7 +102,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
 
          Raises:
          - AssertionError: If CUDA is specified as the device but is not available on the system.
-         - ValueError: If an unsupported prompt mode is provided.
+         - ValueError: If no prompt_template_path is provided and no default applies.
          - ValueError: If num_few_shot_examples > 0 but no valid file path is provided
 
          Note:
@@ -151,10 +151,6 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                     "Open-source listwise reranking with local backends requires PyTorch.",
                 )
             assert torch.cuda.is_available() and torch.cuda.device_count() >= num_gpus
-        if prompt_mode and prompt_mode != PromptMode.RANK_GPT:
-            raise ValueError(
-                f"Unsupported prompt mode: {prompt_mode}. The only prompt mode currently supported is a slight variation of {PromptMode.RANK_GPT} prompt."
-            )
 
         if sglang_batched:
             if Engine is None:

--- a/src/rank_llm/rerank/listwise/rank_litellm.py
+++ b/src/rank_llm/rerank/listwise/rank_litellm.py
@@ -1,6 +1,5 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from importlib.resources import files
 from typing import Any
 
 from tqdm import tqdm
@@ -15,8 +14,6 @@ try:
     import litellm
 except ImportError:
     litellm = None
-
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
 
 
 class SafeLiteLLM(ListwiseRankLLM):
@@ -54,28 +51,6 @@ class SafeLiteLLM(ListwiseRankLLM):
                 "litellm",
                 "The LiteLLM reranker requires the litellm package.",
             )
-
-        if prompt_mode and prompt_mode not in [
-            PromptMode.RANK_GPT,
-            PromptMode.RANK_GPT_APEER,
-            PromptMode.LRL,
-        ]:
-            raise ValueError(
-                f"unsupported prompt mode for LiteLLM: {prompt_mode}, "
-                f"expected {PromptMode.RANK_GPT}, {PromptMode.RANK_GPT_APEER} or {PromptMode.LRL}."
-            )
-
-        if prompt_template_path is None:
-            if prompt_mode == PromptMode.RANK_GPT:
-                prompt_template_path = TEMPLATES / "rank_gpt_template.yaml"
-            elif prompt_mode == PromptMode.RANK_GPT_APEER:
-                prompt_template_path = TEMPLATES / "rank_gpt_apeer_template.yaml"
-            elif prompt_mode == PromptMode.LRL:
-                prompt_template_path = TEMPLATES / "rank_lrl_template.yaml"
-            else:
-                raise ValueError(
-                    "Either `prompt_mode` or `prompt_template_path` must be specified."
-                )
 
         super().__init__(
             model=model,

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -48,9 +48,19 @@ class RankLLM(ABC):
         if prompt_mode:
             warnings.warn(
                 "PromptMode is deprecated and will be removed in v0.30.0. "
-                "Please use the prompt_template_path argument with a valid template file instead.",
+                "It is ignored: prompt behavior is now driven by YAML templates. "
+                "Please use the prompt_template_path argument with a valid YAML "
+                "template instead.",
                 DeprecationWarning,
                 stacklevel=2,
+            )
+
+        if not prompt_template_path:
+            raise ValueError(
+                "A YAML prompt template is required: pass prompt_template_path "
+                "(CLI: --prompt-template-path) pointing to a template under "
+                "src/rank_llm/rerank/prompt_templates/. The legacy prompt_mode "
+                "argument no longer selects a template."
             )
 
         try:

--- a/src/rank_llm/rerank/rankllm.py
+++ b/src/rank_llm/rerank/rankllm.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any
@@ -45,8 +46,11 @@ class RankLLM(ABC):
         self._few_shot_file = few_shot_file
 
         if prompt_mode:
-            print(
-                "PromptMode is deprecated and will be removed in v0.30.0. Please use the prompt_template_path argument with a valid template file instead."
+            warnings.warn(
+                "PromptMode is deprecated and will be removed in v0.30.0. "
+                "Please use the prompt_template_path argument with a valid template file instead.",
+                DeprecationWarning,
+                stacklevel=2,
             )
 
         try:

--- a/src/rank_llm/scripts/run_rank_llm.py
+++ b/src/rank_llm/scripts/run_rank_llm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import warnings
 from collections.abc import Sequence
 
 from rank_llm.cli.legacy import namespace_to_legacy_argv, translate_legacy_argv
@@ -10,18 +11,48 @@ from rank_llm.cli.main import main as cli_main
 # Force spawn method to avoid "Cannot re-initialize CUDA in forked subprocess" error.
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
+# Flags accepted for backwards compatibility but not forwarded to the new CLI.
 _DROP_FLAGS = {"prompt_mode"}
+
+_PROMPT_MODE_DEPRECATION = (
+    "The --prompt_mode CLI flag is deprecated and will be removed in v0.30.0. "
+    "It is now ignored: prompt behavior is driven by YAML templates. "
+    "Pass --prompt-template-path pointing to a template under "
+    "src/rank_llm/rerank/prompt_templates/ instead "
+    "(see `rank-llm prompt --help` to list the available templates)."
+)
+
+
+def _warn_if_prompt_mode_present(args: argparse.Namespace | Sequence[str]) -> None:
+    """Emit a deprecation warning if the legacy --prompt_mode flag was supplied.
+
+    The flag is still accepted so old invocations do not break, but it no longer
+    affects behavior; YAML prompt templates replace it.
+    """
+    if isinstance(args, argparse.Namespace):
+        present = getattr(args, "prompt_mode", None) is not None
+    else:
+        present = any(
+            token in ("--prompt_mode", "--prompt-mode")
+            or token.startswith(("--prompt_mode=", "--prompt-mode="))
+            for token in args
+        )
+    if present:
+        warnings.warn(_PROMPT_MODE_DEPRECATION, DeprecationWarning, stacklevel=3)
 
 
 def main(args: argparse.Namespace | Sequence[str] | None = None) -> int:
     if isinstance(args, argparse.Namespace):
+        _warn_if_prompt_mode_present(args)
         argv = namespace_to_legacy_argv(args, drop_flags=_DROP_FLAGS)
     elif args is None:
         import sys
 
         argv = sys.argv[1:]
+        _warn_if_prompt_mode_present(argv)
     else:
         argv = list(args)
+        _warn_if_prompt_mode_present(argv)
 
     translated = translate_legacy_argv(argv, drop_flags=_DROP_FLAGS)
     return cli_main(["rerank", *translated])

--- a/test/rerank/listwise/test_RankListwiseOSLLM.py
+++ b/test/rerank/listwise/test_RankListwiseOSLLM.py
@@ -6,7 +6,6 @@ from dacite import from_dict
 
 from rank_llm.data import Result
 from rank_llm.rerank.listwise.rank_listwise_os_llm import RankListwiseOSLLM
-from rank_llm.rerank.rankllm import PromptMode
 
 # model, context_size, prompt_template_path, num_few_shot_examples, variable_passages, window_size, system_message
 valid_inputs = [
@@ -81,99 +80,6 @@ valid_inputs = [
         True,
         10,
         "",
-    ),
-]
-
-failure_inputs = [
-    (
-        "castorini/rank_zephyr_7b_v1_full",
-        4096,
-        PromptMode.UNSPECIFIED,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_zephyr_7b_v1_full",
-        4096,
-        PromptMode.LRL,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1",
-        4096,
-        PromptMode.UNSPECIFIED,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1",
-        4096,
-        PromptMode.LRL,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1_noda",
-        4096,
-        PromptMode.UNSPECIFIED,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1_noda",
-        4096,
-        PromptMode.LRL,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1_fp16",
-        4096,
-        PromptMode.UNSPECIFIED,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1_fp16",
-        4096,
-        PromptMode.LRL,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1_noda_fp16",
-        4096,
-        PromptMode.UNSPECIFIED,
-        0,
-        True,
-        30,
-        "Default Message",
-    ),
-    (
-        "castorini/rank_vicuna_7b_v1_noda_fp16",
-        4096,
-        PromptMode.LRL,
-        0,
-        True,
-        30,
-        "Default Message",
     ),
 ]
 
@@ -326,27 +232,6 @@ class TestRankListwiseOSLLM(unittest.TestCase):
             self.assertEqual(model_coordinator._variable_passages, variable_passages)
             self.assertEqual(model_coordinator._window_size, window_size)
             self.assertEqual(model_coordinator._system_message, system_message)
-
-    def test_failure_inputs(self):
-        for (
-            model,
-            context_size,
-            prompt_mode,
-            num_few_shot_examples,
-            variable_passages,
-            window_size,
-            system_message,
-        ) in failure_inputs:
-            with self.assertRaises(ValueError):
-                RankListwiseOSLLM(
-                    model=model,
-                    context_size=context_size,
-                    prompt_mode=prompt_mode,
-                    num_few_shot_examples=num_few_shot_examples,
-                    variable_passages=variable_passages,
-                    window_size=window_size,
-                    system_message=system_message,
-                )
 
     @patch(
         "rank_llm.rerank.listwise.rank_listwise_os_llm.RankListwiseOSLLM.num_output_tokens"

--- a/test/rerank/test_rankllm.py
+++ b/test/rerank/test_rankllm.py
@@ -1,0 +1,79 @@
+import unittest
+import warnings
+
+from rank_llm.rerank.rankllm import PromptMode, RankLLM
+
+# A real template so RankLLM.__init__ can build an inference handler.
+_TEMPLATE = "src/rank_llm/rerank/prompt_templates/rank_gpt_template.yaml"
+
+
+class _MinimalRankLLM(RankLLM):
+    """Smallest concrete RankLLM subclass so the abstract base can be
+    instantiated in tests. The abstract methods are never exercised here;
+    only __init__ behavior (the prompt_mode deprecation) is under test.
+    """
+
+    def run_llm_batched(self, prompts, **kwargs):
+        return []
+
+    def run_llm(self, prompt, **kwargs):
+        return "", 0
+
+    def create_prompt_batched(self, results, rank_start, rank_end):
+        return []
+
+    def create_prompt(self, result, rank_start, rank_end):
+        return "", 0
+
+    def get_num_tokens(self, prompt):
+        return 0
+
+    def cost_per_1k_token(self, input_token):
+        return 0.0
+
+    def num_output_tokens(self):
+        return 0
+
+    def rerank_batch(
+        self,
+        requests,
+        rank_start=0,
+        rank_end=100,
+        shuffle_candidates=False,
+        logging=False,
+        **kwargs,
+    ):
+        return []
+
+    def get_output_filename(
+        self, top_k_candidates, dataset_name, shuffle_candidates, **kwargs
+    ):
+        return ""
+
+
+class TestPromptModeDeprecation(unittest.TestCase):
+    def _make(self, **kwargs):
+        return _MinimalRankLLM(
+            model="dummy",
+            context_size=4096,
+            prompt_template_path=_TEMPLATE,
+            **kwargs,
+        )
+
+    def test_prompt_mode_emits_deprecation_warning(self):
+        with self.assertWarns(DeprecationWarning) as ctx:
+            self._make(prompt_mode=PromptMode.RANK_GPT)
+        self.assertIn("PromptMode is deprecated", str(ctx.warning))
+
+    def test_no_prompt_mode_emits_no_deprecation_warning(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._make()  # prompt_mode defaults to None
+        prompt_mode_warnings = [
+            w for w in caught if "PromptMode is deprecated" in str(w.message)
+        ]
+        self.assertEqual(prompt_mode_warnings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_cli_legacy_wrappers.py
+++ b/test/test_cli_legacy_wrappers.py
@@ -1,5 +1,6 @@
 import argparse
 import unittest
+import warnings
 from unittest.mock import Mock, patch
 
 from rank_llm.scripts import (
@@ -41,6 +42,62 @@ class TestCLILegacyWrappers(unittest.TestCase):
                 "--use-azure-openai",
             ],
         )
+
+    def test_run_rank_llm_wrapper_warns_and_drops_deprecated_prompt_mode(self):
+        with patch("rank_llm.scripts.run_rank_llm.cli_main", return_value=0) as mocked:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                exit_code = run_rank_llm.main(
+                    [
+                        "--model_path",
+                        "model",
+                        "--prompt_mode",
+                        "rank_GPT",
+                        "--requests_file",
+                        "requests.jsonl",
+                    ]
+                )
+
+        self.assertEqual(exit_code, 0)
+        prompt_mode_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "prompt_mode" in str(w.message)
+        ]
+        self.assertEqual(len(prompt_mode_warnings), 1)
+        # The deprecated flag is still accepted but never forwarded to the CLI.
+        self.assertNotIn("--prompt-mode", mocked.call_args.args[0])
+        self.assertNotIn("rank_GPT", mocked.call_args.args[0])
+        self.assertEqual(
+            mocked.call_args.args[0],
+            [
+                "rerank",
+                "--model-path",
+                "model",
+                "--requests-file",
+                "requests.jsonl",
+            ],
+        )
+
+    def test_run_rank_llm_wrapper_warns_on_deprecated_prompt_mode_namespace(self):
+        with patch("rank_llm.scripts.run_rank_llm.cli_main", return_value=0):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                run_rank_llm.main(
+                    argparse.Namespace(
+                        model_path="model",
+                        prompt_mode="rank_GPT",
+                    )
+                )
+
+        prompt_mode_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "prompt_mode" in str(w.message)
+        ]
+        self.assertEqual(len(prompt_mode_warnings), 1)
 
     def test_run_trec_eval_wrapper_delegates_to_evaluate(self):
         with patch("rank_llm.scripts.run_trec_eval.cli_main", return_value=0) as mocked:


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

Please provide the reference to issue this PR is addressing (# followed by the issue number). If there is no associated issue, write "N/A".

ref: https://github.com/castorini/rank_llm/issues/248

## Summary

- Very simple fix which used deprecation warning instead of print.

## Why

Now that all the inference handlers are created, the old prompt_mode argument needs to be gracefully deprecated

## Validation

List the exact commands you ran, for example:

```bash
uv run python -c "
from rank_llm.rerank.rankllm import RankLLM, PromptMode
class _Dummy(RankLLM): pass
_Dummy.__abstractmethods__ = frozenset()
_Dummy(model='dummy', context_size=4096, prompt_mode=PromptMode.RANK_GPT,
       prompt_template_path='src/rank_llm/rerank/prompt_templates/rank_gpt_template.yaml')
"
```

## Follow-ups
On the prompt_mode deprecation: I changed the message to a proper DeprecationWarning, it is a bit too simple so please correct me if I misunderstood the problem.


## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
