### PR TITLE
Parameterize firstmistral nemotron

### DIFF
--- a/src/rank_llm/demo/rerank_firstmistral.py
+++ b/src/rank_llm/demo/rerank_firstmistral.py
@@ -167,7 +167,7 @@ def main() -> None:
         use_alpha=args.use_alpha,
     )
     reranker = Reranker(coordinator)
-    kwargs = {"populate_invocations_history": True}
+    kwargs = {"populate_invocations_history": True, "top_k_retrieve": args.k}
 
     print(f"\n--- Batched reranking ({len(requests)} queries) ---")
     rerank_results = reranker.rerank_batch(requests, **kwargs)

--- a/src/rank_llm/demo/rerank_firstmistral.py
+++ b/src/rank_llm/demo/rerank_firstmistral.py
@@ -1,3 +1,28 @@
+"""
+Listwise reranking demo with FIRST-Mistral (e.g. ``castorini/first_mistral``)
+on top of BM25 first-stage retrieval from a Pyserini prebuilt index.
+
+FIRST is the "first-token logit" listwise reranker: instead of asking the
+model to emit an ordering token-by-token, the prompt invites a single
+permutation token whose logit distribution over the candidate IDs is read
+directly. ``use_logits=True`` enables that fast path and ``use_alpha=True``
+re-labels candidates with alphabet IDs (A, B, C, ...) instead of numeric
+IDs, which keeps the permutation token a single piece for most tokenizers.
+
+Prerequisites:
+  pip install -e '.[pyserini,vllm]'
+
+Usage (from repo root):
+  python src/rank_llm/demo/rerank_firstmistral.py
+  python src/rank_llm/demo/rerank_firstmistral.py \\
+      --dataset dl20 \\
+      --num-queries 5 \\
+      --skip-eval
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -8,34 +33,172 @@ parent = os.path.dirname(parent)
 sys.path.append(parent)
 
 from rank_llm.analysis.response_analysis import ResponseAnalyzer
-from rank_llm.data import DataWriter
+from rank_llm.data import DataWriter, Result
+from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker
 from rank_llm.rerank.listwise import RankListwiseOSLLM
-from rank_llm.retrieve import Retriever
+from rank_llm.retrieve import TOPICS
+from rank_llm.retrieve.retriever import Retriever
 
-# By default uses BM25 for retrieval
-dataset_name = "dl19"
-requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
-model_coordinator = RankListwiseOSLLM(
-    model="castorini/first_mistral",
-    use_logits=True,
-    use_alpha=True,
-)
-reranker = Reranker(model_coordinator)
-kwargs = {"populate_invocations_history": True}
-rerank_results = reranker.rerank_batch(requests, **kwargs)
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-# Analyze the response
-analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=True)
 
-error_counts = analyzer.count_errors()
-print(error_counts.__repr__())
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
 
-# Write rerank results
-writer = DataWriter(rerank_results)
-Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-writer.write_in_jsonl_format("demo_outputs/rerank_results.jsonl")
-writer.write_in_trec_eval_format("demo_outputs/rerank_results.txt")
-writer.write_inference_invocations_history(
-    "demo_outputs/inference_invocations_history.json"
-)
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise FIRST-Mistral reranking on BM25 first-stage results."
+    )
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with a Pyserini prebuilt index (default: dl19).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--model",
+        default="castorini/first_mistral",
+        help="HuggingFace model id (default: castorini/first_mistral).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Per-step batch size (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size for the model (default: 4096).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--use-logits",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use the FIRST fast-path single-token logit decode (--use-logits / --no-use-logits, default on).",
+    )
+    p.add_argument(
+        "--use-alpha",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Label candidates with A/B/C... alphabet IDs (--use-alpha / --no-use-alpha, default on; required by FIRST).",
+    )
+    p.add_argument(
+        "--num-gpus",
+        type=int,
+        default=1,
+        help="Number of GPUs for tensor parallelism (default: 1).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    args = p.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    coordinator = RankListwiseOSLLM(
+        model=args.model,
+        context_size=args.context_size,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        num_gpus=args.num_gpus,
+        use_logits=args.use_logits,
+        use_alpha=args.use_alpha,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {"populate_invocations_history": True}
+
+    print(f"\n--- Batched reranking ({len(requests)} queries) ---")
+    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    print(f"Reranked {len(rerank_results)} results.")
+    _print_sample(rerank_results)
+
+    analyzer = ResponseAnalyzer.from_inline_results(
+        rerank_results, use_alpha=args.use_alpha
+    )
+    error_counts = analyzer.count_errors()
+    print(f"\nResponse analysis: {error_counts!r}")
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
+
+    # --- Save outputs ---
+    model_tag = args.model.split("/")[-1].lower()
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_firstmistral.py
+++ b/src/rank_llm/demo/rerank_firstmistral.py
@@ -167,7 +167,11 @@ def main() -> None:
         use_alpha=args.use_alpha,
     )
     reranker = Reranker(coordinator)
-    kwargs = {"populate_invocations_history": True, "top_k_retrieve": args.k}
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
 
     print(f"\n--- Batched reranking ({len(requests)} queries) ---")
     rerank_results = reranker.rerank_batch(requests, **kwargs)

--- a/src/rank_llm/demo/rerank_nemotron_nano_v2.py
+++ b/src/rank_llm/demo/rerank_nemotron_nano_v2.py
@@ -113,6 +113,7 @@ def run_mode(
         requests,
         populate_invocations_history=True,
         top_k_retrieve=args.k,
+        rank_end=args.k,
     )
     print(f"Reranked {len(rerank_results)} results.")
     _print_sample(rerank_results)

--- a/src/rank_llm/demo/rerank_nemotron_nano_v2.py
+++ b/src/rank_llm/demo/rerank_nemotron_nano_v2.py
@@ -1,80 +1,245 @@
 """
-NVIDIA-Nemotron-Nano-9B-v2 reranker with vLLM
-Runs both thinking and non-thinking modes back-to-back.
+Listwise reranking demo with NVIDIA-Nemotron-Nano-9B-v2 (default
+``nvidia/NVIDIA-Nemotron-Nano-9B-v2``) on top of BM25 first-stage retrieval
+from a Pyserini prebuilt index.
+
+Nemotron-Nano-v2 ships with both a thinking and a non-thinking prompt
+template. Each mode uses its own YAML in
+``rank_llm.rerank.prompt_templates`` and toggles ``is_thinking`` on the
+RankListwiseOSLLM coordinator. The ``--variant`` flag selects which mode
+to run; ``both`` runs them back-to-back (matching the original hardcoded
+demo's behavior).
+
+Prerequisites:
+  pip install -e '.[pyserini,vllm]'
+
+Usage (from repo root):
+  python src/rank_llm/demo/rerank_nemotron_nano_v2.py
+  python src/rank_llm/demo/rerank_nemotron_nano_v2.py \\
+      --variant thinking \\
+      --dataset dl20 \\
+      --num-queries 5 \\
+      --skip-eval
 """
 
+from __future__ import annotations
+
+import argparse
+import os
+import sys
 from importlib.resources import files
 from pathlib import Path
 
-from rank_llm.data import DataWriter
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
+
+# --- set spawn before importing libs that might touch CUDA/vLLM ---
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+import multiprocessing as mp
+
+try:
+    mp.set_start_method("spawn")
+except RuntimeError:
+    pass  # already set, fine
+
+from rank_llm.data import DataWriter, Result
 from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker
 from rank_llm.rerank.listwise import RankListwiseOSLLM
-from rank_llm.retrieve import Retriever
-from rank_llm.retrieve.topics_dict import TOPICS
+from rank_llm.retrieve import TOPICS
+from rank_llm.retrieve.retriever import Retriever
 
-DATASET = "dl19"
-TOP_K = 100
-
-# retrieval only once (same for both modes)
-requests = Retriever.from_dataset_with_prebuilt_index(DATASET, k=TOP_K)
-topics = TOPICS[DATASET]
 TEMPLATES = files("rank_llm.rerank.prompt_templates")
 
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-def run_mode(thinking: bool):
-    """Run Nemotron reranker in either thinking or non-thinking mode."""
+
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def run_mode(
+    args: argparse.Namespace,
+    requests: list,
+    qrels: str | None,
+    thinking: bool,
+) -> list[Result]:
     mode_name = "thinking" if thinking else "nothink"
-    template_file = (
-        "nemotron_thinking_template.yaml"
-        if thinking
-        else "nemotron_nonthinking_template.yaml"
+    template_path = (
+        args.thinking_template if thinking else args.nothinking_template
+    ) or str(
+        TEMPLATES
+        / (
+            "nemotron_thinking_template.yaml"
+            if thinking
+            else "nemotron_nonthinking_template.yaml"
+        )
     )
-    template_path = str(TEMPLATES / template_file)
 
-    print(f"\n=== Running {mode_name} mode ===")
-    print(f"Template: {template_file}")
+    print("\n=========================================================")
+    print(f"Nemotron Nano v2 — {mode_name} mode")
+    print("=========================================================")
+    print(f"Template: {template_path}")
 
-    model_coordinator = RankListwiseOSLLM(
-        model="nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+    coordinator = RankListwiseOSLLM(
+        model=args.model,
         prompt_template_path=template_path,
+        context_size=args.context_size,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        num_gpus=args.num_gpus,
         is_thinking=thinking,
     )
-    reranker = Reranker(model_coordinator)
+    reranker = Reranker(coordinator)
 
-    # rerank all queries
     rerank_results = reranker.rerank_batch(
         requests,
         populate_invocations_history=True,
-        top_k_retrieve=TOP_K,
+        top_k_retrieve=args.k,
     )
+    print(f"Reranked {len(rerank_results)} results.")
+    _print_sample(rerank_results)
 
-    # metrics
-    bm25_score = EvalFunction.from_results(requests, topics)  # string
-    rerank_score = EvalFunction.from_results(rerank_results, topics)  # string
+    if qrels and not args.skip_eval:
+        print(f"\nReranking metrics  ({args.model}, {mode_name})")
+        _print_eval(rerank_results, qrels)
 
-    # Print EXACTLY like your original code (no numeric formatting)
-    print(f"BM25 ndcg@10: {bm25_score}")
-    print(f"Rerank ndcg@10: {rerank_score}")
-
-    # Save results
-    outdir = Path(f"demo_outputs/{DATASET}/nemotron_nano_v2_{mode_name}")
-    outdir.mkdir(parents=True, exist_ok=True)
+    # --- Save outputs ---
+    model_tag = args.model.split("/")[-1].lower() + f"-{mode_name}"
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs") / args.dataset / f"nemotron_nano_v2_{mode_name}"
+    out_path.mkdir(parents=True, exist_ok=True)
 
     writer = DataWriter(rerank_results)
-    writer.write_in_jsonl_format(outdir / "rerank_results.jsonl")
-    writer.write_in_trec_eval_format(outdir / "rerank_results.txt")
-    writer.write_inference_invocations_history(
-        outdir / "inference_invocations_history.json"
-    )
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
 
-    # Write eval results (compute improvement safely, but keep printed lines unchanged)
-    with open(outdir / "eval_results.txt", "w") as f:
-        f.write(f"BM25 ndcg@10: {bm25_score}\n")
-        f.write(f"Rerank ndcg@10: {rerank_score}\n")
+    return rerank_results
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise NVIDIA-Nemotron-Nano-9B-v2 reranking on BM25 first-stage results."
+    )
+    p.add_argument(
+        "--variant",
+        choices=("both", "thinking", "nothink"),
+        default="both",
+        help="Which Nemotron mode to run (default: both — runs thinking then "
+        "non-thinking back-to-back, matching the original hardcoded script).",
+    )
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with a Pyserini prebuilt index (default: dl19).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--model",
+        default="nvidia/NVIDIA-Nemotron-Nano-9B-v2",
+        help="HuggingFace model id (default: nvidia/NVIDIA-Nemotron-Nano-9B-v2).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Per-step batch size (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size for the model (default: 4096).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--thinking-template",
+        default=None,
+        help="Override prompt template path for thinking mode (default: bundled nemotron_thinking_template.yaml).",
+    )
+    p.add_argument(
+        "--nothinking-template",
+        default=None,
+        help="Override prompt template path for non-thinking mode (default: bundled nemotron_nonthinking_template.yaml).",
+    )
+    p.add_argument(
+        "--num-gpus",
+        type=int,
+        default=1,
+        help="Number of GPUs for tensor parallelism (default: 1).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    args = p.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\nRetrieval metrics  (BM25, k={args.k})")
+        _print_eval(requests, qrels)
+
+    if args.variant in ("both", "thinking"):
+        run_mode(args, requests, qrels, thinking=True)
+    if args.variant in ("both", "nothink"):
+        run_mode(args, requests, qrels, thinking=False)
 
 
 if __name__ == "__main__":
-    print(f"Testing Nemotron Nano 9B v2 on {DATASET} (BM25 top-{TOP_K})")
-    run_mode(thinking=True)
-    run_mode(thinking=False)
+    main()


### PR DESCRIPTION
Title:
  Parameterize rerank_firstmistral and rerank_nemotron_nano_v2 demos

  Body:
  
  ref: #390

  Two more demo scripts parameterized to match the rerank_qwen_local.py
  argparse template established by #393 and #396:

  `castorini/first_mistral`, `use_logits` + `use_alpha` on by default
  (preserves the original demo's behavior). New flags: `--dataset`, `--k`,
  `--model`, `--batch-size`, `--context-size`, `--window-size`, `--stride`,
  `--use-logits`/`--no-use-logits`, `--use-alpha`/`--no-use-alpha`,
  `--num-gpus`, `--num-queries`, `--output-dir`, `--skip-eval`. Inline
  trec_eval metrics output added (the original demo didn't have it).

  - **rerank_nemotron_nano_v2.py** — listwise NVIDIA-Nemotron-Nano-9B-v2
  with both thinking and non-thinking prompt templates. New `--variant
  {both,thinking,nothink}` flag (default `both`) preserves the original
  script's "thinking then non-thinking back-to-back" behavior. Other flags
  match the rest of the family, plus `--thinking-template` /
  `--nothinking-template` for template overrides.
  
  ## Validation
  Pre-commit clean for both. `--help` exits 0 with all flags wired.

  End-to-end on dragon (RTX 4090, vLLM 0.19.1, torch 2.10+cu128,
  transformers 5.9.0), `--num-queries 4` on dl19:

  | Metric     | BM25   | firstmistral | nemotron (nothink) |
  |------------|--------|--------------|---------------------|
  | nDCG@10    | 0.6201 | **0.9265**   | 0.6067              |
  | MAP@100    | 0.2052 | **0.3456**   | **0.2653**          |
  | Recall@20  | 0.2110 | 0.2356       | 0.2125              |
  | Recall@100 | 0.4303 | 0.4303       | 0.4303              |
  
  - **firstmistral**: 36/36 windows ok across the 4 queries, 0 format
  errors. Solid +49% nDCG@10 lift.
  - **nemotron (nothink)**: demo wires through cleanly; MAP@100 improves
  +29% on these 4 queries but top-10 nDCG dips ~2%. Likely small-sample
  variance and/or the nothink template being less effective than thinking on
   this query mix — the underlying reranker logic is unchanged from the
  original hardcoded demo. Happy to run the full `--variant both` or extend
  the query set if requested.