### PR TITLE
feat: add Colab CLI common plumbing (remote bootstrap + shared bash h…

### DIFF
--- a/colab/README.md
+++ b/colab/README.md
@@ -1,0 +1,50 @@
+# rank_llm on Google Colab (Colab CLI recipes)
+
+Shared plumbing for self-contained recipes that drive the
+[Google Colab CLI](https://github.com/googlecolab/google-colab-cli) to run
+rank_llm workloads on a remote Colab GPU, then download the results to your
+machine. Nothing in the core `rank_llm` package is modified — everything lives
+in this directory.
+
+This directory currently contains the shared helpers; the runnable recipes
+(`rerank_on_colab.sh`, `train_on_colab.sh`) build on top of them in follow-up
+changes.
+
+## What's here
+
+| File | Purpose |
+| --- | --- |
+| `_remote_bootstrap.py` | Sent to the runtime by `colab exec -f`. Clones rank_llm, installs extras, runs the job, prints `ARTIFACT_PATH=`. |
+| `_colab_common.sh` | Shared bash helpers (provision / exec / download / DRY_RUN). |
+
+## How it works
+
+`colab exec` only transmits **one** file and can't pass argv. So each orchestrator
+builds a temp bootstrap file = an injected `CONFIG = json.loads(...)` line
+prepended to `_remote_bootstrap.py`, and sends that. The runtime script then
+clones rank_llm, `pip install`s the right extras, runs the command, and prints
+`ARTIFACT_PATH=<remote .tar.gz>` on its last line for the caller to `colab download`.
+
+## Prerequisites (for live use)
+
+Install and authenticate the CLI once (Linux/macOS only):
+
+```bash
+uv tool install git+https://github.com/googlecolab/google-colab-cli
+# then authenticate per the CLI's prompts
+```
+
+## Manual testing
+
+Offline checks (no Colab account, no GPU spend):
+
+```bash
+# 1. The remote bootstrap compiles
+python3 -m py_compile colab/_remote_bootstrap.py
+
+# 2. Shell helpers parse
+bash -n colab/_colab_common.sh
+
+# 3. Optional: lint (no pip needed)
+uv tool run --from shellcheck-py shellcheck -x colab/*.sh
+```

--- a/colab/_colab_common.sh
+++ b/colab/_colab_common.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Shared helpers for the rank_llm Colab CLI recipes.
+# Sourced by train_on_colab.sh and rerank_on_colab.sh.
+#
+# Real Colab CLI surface these wrap (see `colab -h`):
+#   colab new   --gpu A100 -s NAME        provision a named session
+#   colab exec  -f FILE -s NAME --timeout N   run a file in that session
+#   colab download REMOTE LOCAL -s NAME   pull an artifact back
+#   colab stop  -s NAME                    release the runtime
+
+COLAB_BIN="${COLAB_BIN:-colab}"
+COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_PY="$COMMON_DIR/_remote_bootstrap.py"
+
+# Run a `colab` subcommand, or just print it when DRY_RUN=1.
+run_colab() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '[dry-run] %s' "$COLAB_BIN"
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$COLAB_BIN" "$@"
+  fi
+}
+
+# Fail early with an install hint if the CLI is missing (skipped in dry-run).
+require_colab() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    return 0
+  fi
+  if ! command -v "$COLAB_BIN" >/dev/null 2>&1; then
+    echo "error: '$COLAB_BIN' not found." >&2
+    echo "Install it with: uv tool install git+https://github.com/googlecolab/google-colab-cli" >&2
+    exit 1
+  fi
+}
+
+# Build a temp bootstrap file: an injected `CONFIG = json.loads(...)` line
+# prepended to _remote_bootstrap.py. Echoes the temp file path.
+build_bootstrap() {
+  local cfg_json="$1"
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/rankllm_colab_bootstrap.XXXXXX.py")"
+  {
+    printf 'import json\nCONFIG = json.loads(r"""%s""")\n' "$cfg_json"
+    cat "$BOOTSTRAP_PY"
+  } >"$tmp"
+  printf '%s\n' "$tmp"
+}
+
+# Create a named session with the requested accelerator.
+provision_gpu() {
+  local gpu="$1" session="$2"
+  echo "==> Creating Colab session '$session' (--gpu $gpu)"
+  run_colab new --gpu "$gpu" -s "$session"
+}
+
+# Run `colab exec -f FILE` with retries. A freshly-READY kernel often drops the
+# first websocket connection ("Connection was lost"), and long-held sockets can
+# drop mid-run; the bootstrap is idempotent (clone skips if present), so retrying
+# is safe. Tunable via EXEC_RETRIES / EXEC_RETRY_WAIT.
+colab_exec_file() {
+  local file="$1" session="$2" timeout="$3"
+  local attempts="${EXEC_RETRIES:-3}" wait="${EXEC_RETRY_WAIT:-15}" n=1
+  while true; do
+    if run_colab exec -f "$file" -s "$session" --timeout "$timeout"; then
+      return 0
+    fi
+    if ((n >= attempts)); then
+      echo "error: 'colab exec' failed after ${attempts} attempt(s)." >&2
+      return 1
+    fi
+    echo "   exec attempt ${n}/${attempts} failed; retrying in ${wait}s..." >&2
+    sleep "$wait"
+    n=$((n + 1))
+  done
+}
+
+# Poke the kernel with a trivial cell so the websocket stabilizes before the real
+# (long) exec. This absorbs the common post-READY "Connection was lost" race.
+warmup_kernel() {
+  local session="$1" tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/rankllm_warmup.XXXXXX.py")"
+  printf 'print("kernel warmup ok")\n' >"$tmp"
+  echo "==> Warming up kernel on '$session'"
+  colab_exec_file "$tmp" "$session" 30
+  local rc=$?
+  rm -f "$tmp"
+  return $rc
+}
+
+# The default exec timeout is 30s, far too short for installs + model runs, so
+# callers pass a large value. Retries are handled by colab_exec_file.
+exec_bootstrap() {
+  local tmp="$1" session="$2" timeout="$3"
+  echo "==> Executing remote bootstrap on '$session' (timeout ${timeout}s)"
+  colab_exec_file "$tmp" "$session" "$timeout"
+}
+
+# Download a single remote artifact (a .tar.gz) into a local directory.
+download_artifact() {
+  local remote="$1" local_dir="$2" session="$3"
+  local fname
+  fname="$(basename "$remote")"
+  echo "==> Downloading $remote -> $local_dir/$fname"
+  if [[ "${DRY_RUN:-0}" != "1" ]]; then
+    mkdir -p "$local_dir"
+  fi
+  run_colab download "$remote" "$local_dir/$fname" -s "$session"
+  echo "Done. Unpack with: tar xzf $local_dir/$fname -C $local_dir"
+}
+
+# Release the runtime (skipped when KEEP_SESSION=1 so you can debug via
+# `colab exec -s NAME`). Tolerates a missing session.
+stop_session() {
+  local session="$1"
+  if [[ "${KEEP_SESSION:-0}" == "1" ]]; then
+    echo "==> KEEP_SESSION=1, leaving session '$session' running (stop with: colab stop -s $session)"
+    return 0
+  fi
+  echo "==> Stopping Colab session '$session'"
+  run_colab stop -s "$session" || true
+}

--- a/colab/_remote_bootstrap.py
+++ b/colab/_remote_bootstrap.py
@@ -1,0 +1,266 @@
+"""Remote bootstrap executed on a Google Colab runtime via ``colab exec -f``.
+
+This file is sent verbatim to a provisioned Colab kernel by the local
+orchestration scripts (``train_on_colab.sh`` / ``rerank_on_colab.sh``).
+
+``colab exec`` only transmits a single file and provides no way to pass argv,
+so the orchestration script prepends a line of the form::
+
+    CONFIG = {"mode": "train", "base_model": "...", ...}
+
+before the contents of this file and executes the concatenation. The merge
+below lets that injected dict override the defaults while keeping this file
+independently importable / lintable (``CONFIG`` is always defined).
+
+The script clones rank_llm, installs the right extras, runs the requested
+training or reranking command, and prints ``ARTIFACT_PATH=<remote path>`` on
+the last line so the caller knows what to ``colab download``.
+"""
+
+import os
+import shlex
+import subprocess
+import sys
+
+DEFAULT_CONFIG = {
+    # Common
+    "mode": "train",  # "train" | "rerank"
+    "repo_url": "https://github.com/castorini/rank_llm.git",
+    "ref": "main",
+    "workdir": "/content/rank_llm",
+    "install_flash_attn": False,
+    # Training
+    "base_model": "HuggingFaceH4/zephyr-7b-beta",
+    "train_dataset_path": "rryisthebest/rank_zephyr_training_data_alpha",
+    "objective": "generation",  # generation | ranking | combined
+    "output_dir": "/content/rank_llm/training/models/colab_run",
+    "num_train_epochs": 1,
+    "per_device_train_batch_size": 1,
+    "gradient_accumulation_steps": 16,
+    "num_warmup_steps": 10,
+    "lr_scheduler_type": "cosine",
+    "seed": 42,
+    "extra_train_args": [],  # e.g. ["--ranking_loss", "ranknet", "--weighted"]
+    # Reranking
+    "model_path": "castorini/rank_zephyr_7b_v1_full",
+    "rerank_mode": "dataset",  # "dataset" | "requests_url"
+    "dataset": "dl19",
+    "retrieval_method": "SPLADE++_EnsembleDistil_ONNX",
+    "requests_url": "",  # used when rerank_mode == "requests_url"
+    "top_k": 100,
+    "context_size": 4096,
+    "num_gpus": 1,
+    "install_pyserini": True,  # needed for dataset-mode retrieval (JDK 21)
+    "extra_rerank_args": [],
+}
+
+# The orchestration script may inject a partial ``CONFIG`` before this file;
+# merge it over the defaults. Accessing via ``globals()`` keeps this valid when
+# the file is run standalone (no injection) so linters/py_compile stay happy.
+CONFIG = {**DEFAULT_CONFIG, **globals().get("CONFIG", {})}
+
+
+def run(cmd, cwd=None, env=None):
+    """Run a command, streaming its output; raise on non-zero exit.
+
+    Colab's kernel only surfaces the Python ``sys.stdout``, not a child
+    process's OS-level stdout/stderr. So we merge the child's streams and
+    re-print them through ``print`` line by line — otherwise subprocess errors
+    (which go to stderr) are invisible in the ``colab exec`` output.
+    """
+    printable = cmd if isinstance(cmd, str) else shlex.join(cmd)
+    print(f"\n>>> {printable}", flush=True)
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        shell=isinstance(cmd, str),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    for line in proc.stdout:
+        print(line, end="", flush=True)
+    proc.wait()
+    if proc.returncode != 0:
+        raise SystemExit(f"Command failed (exit {proc.returncode}): {printable}")
+
+
+def clone_repo():
+    workdir = CONFIG["workdir"]
+    if os.path.isdir(os.path.join(workdir, ".git")):
+        print(f"Repo already present at {workdir}, skipping clone.", flush=True)
+        return
+    run(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "-b",
+            str(CONFIG["ref"]),
+            CONFIG["repo_url"],
+            workdir,
+        ]
+    )
+
+
+def pip_install(spec, editable=False):
+    cmd = [sys.executable, "-m", "pip", "install", "-q"]
+    if editable:
+        cmd.append("-e")
+    cmd.append(spec)
+    run(cmd)
+
+
+def install_apt_jdk21():
+    # rank_llm retrieval (pyserini/anserini) requires JDK 21.
+    run("apt-get update -qq && apt-get install -y -qq openjdk-21-jdk-headless")
+
+
+def archive(path):
+    """Tar a result directory into a single file for a clean `colab download`."""
+    path = path.rstrip("/")
+    tar = path + ".tar.gz"
+    parent = os.path.dirname(path) or "."
+    base = os.path.basename(path)
+    run(["tar", "czf", tar, "-C", parent, base])
+    return tar
+
+
+def do_train():
+    clone_repo()
+    workdir = CONFIG["workdir"]
+    pip_install(f"{workdir}[training]", editable=True)
+    if CONFIG["install_flash_attn"]:
+        run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-q",
+                "flash-attn",
+                "--no-build-isolation",
+            ]
+        )
+
+    output_dir = CONFIG["output_dir"]
+    os.makedirs(output_dir, exist_ok=True)
+
+    env = dict(os.environ)
+    env["DS_SKIP_CUDA_CHECK"] = "1"
+    env["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+    cmd = [
+        "accelerate",
+        "launch",
+        "--config_file",
+        "configs/accel_config_single_gpu.yaml",
+        "train_rankllm.py",
+        "--model_name_or_path",
+        str(CONFIG["base_model"]),
+        "--train_dataset_path",
+        str(CONFIG["train_dataset_path"]),
+        "--objective",
+        str(CONFIG["objective"]),
+        "--num_train_epochs",
+        str(CONFIG["num_train_epochs"]),
+        "--per_device_train_batch_size",
+        str(CONFIG["per_device_train_batch_size"]),
+        "--gradient_accumulation_steps",
+        str(CONFIG["gradient_accumulation_steps"]),
+        "--num_warmup_steps",
+        str(CONFIG["num_warmup_steps"]),
+        "--lr_scheduler_type",
+        str(CONFIG["lr_scheduler_type"]),
+        "--seed",
+        str(CONFIG["seed"]),
+        "--gradient_checkpointing",
+        "--low_cpu_mem_usage",
+        "--output_dir",
+        output_dir,
+        "--checkpointing_steps",
+        "epoch",
+    ]
+    cmd += [str(a) for a in CONFIG["extra_train_args"]]
+    run(cmd, cwd=os.path.join(workdir, "training"), env=env)
+    return archive(output_dir)
+
+
+def do_rerank():
+    clone_repo()
+    workdir = CONFIG["workdir"]
+    pyserini = CONFIG["install_pyserini"] and CONFIG["rerank_mode"] == "dataset"
+    spec = f"{workdir}[vllm,pyserini]" if pyserini else f"{workdir}[vllm]"
+    if pyserini:
+        install_apt_jdk21()
+    pip_install(spec, editable=True)
+    # ONNX learned-sparse retrievers (e.g. SPLADE++_EnsembleDistil_ONNX) need
+    # onnxruntime for the query encoder; the pyserini extra does not pull it in.
+    if pyserini and "onnx" in str(CONFIG["retrieval_method"]).lower():
+        pip_install("onnxruntime")
+
+    out_dir = os.path.join(workdir, "colab_rerank_out")
+    os.makedirs(out_dir, exist_ok=True)
+    out_jsonl = os.path.join(out_dir, "results.jsonl")
+    out_trec = os.path.join(out_dir, "results.trec")
+
+    cmd = [
+        "rank-llm",
+        "rerank",
+        "--model-path",
+        str(CONFIG["model_path"]),
+        "--num-gpus",
+        str(CONFIG["num_gpus"]),
+        "--context-size",
+        str(CONFIG["context_size"]),
+        "--output-jsonl-file",
+        out_jsonl,
+        "--output-trec-file",
+        out_trec,
+    ]
+
+    if CONFIG["rerank_mode"] == "requests_url":
+        req_file = os.path.join(out_dir, "requests.jsonl")
+        run(["wget", "-q", "-O", req_file, str(CONFIG["requests_url"])])
+        cmd += ["--requests-file", req_file]
+    else:
+        cmd += [
+            "--dataset",
+            str(CONFIG["dataset"]),
+            "--retrieval-method",
+            str(CONFIG["retrieval_method"]),
+            "--top-k-candidates",
+            str(CONFIG["top_k"]),
+        ]
+
+    cmd += [str(a) for a in CONFIG["extra_rerank_args"]]
+    # Unbuffered so the child's stdout (model/retrieval progress) is interleaved
+    # with stderr in real time instead of being lost if the process crashes.
+    env = dict(os.environ)
+    env["PYTHONUNBUFFERED"] = "1"
+    # pyserini 1.2.0 eagerly builds an ``openai.OpenAI()`` client at import time
+    # (pyserini/encode/_openai.py). With openai>=2 that raises when no key is set
+    # — even for bm25 retrieval that never touches OpenAI. A placeholder lets the
+    # import succeed; the client is never actually called. A real key is kept.
+    env.setdefault("OPENAI_API_KEY", "sk-pyserini-import-placeholder")
+    run(cmd, cwd=workdir, env=env)
+    return archive(out_dir)
+
+
+def main():
+    mode = CONFIG["mode"]
+    if mode == "train":
+        artifact = do_train()
+    elif mode == "rerank":
+        artifact = do_rerank()
+    else:
+        raise SystemExit(f"Unknown mode: {mode!r} (expected 'train' or 'rerank')")
+    # Last line is parsed by the orchestration script for `colab download`.
+    print(f"\nARTIFACT_PATH={artifact}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/colab/_remote_bootstrap.py
+++ b/colab/_remote_bootstrap.py
@@ -19,6 +19,7 @@ the last line so the caller knows what to ``colab download``.
 
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 
@@ -89,21 +90,27 @@ def run(cmd, cwd=None, env=None):
 
 def clone_repo():
     workdir = CONFIG["workdir"]
+    repo_url = CONFIG["repo_url"]
+    ref = str(CONFIG["ref"])
     if os.path.isdir(os.path.join(workdir, ".git")):
-        print(f"Repo already present at {workdir}, skipping clone.", flush=True)
-        return
-    run(
-        [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "-b",
-            str(CONFIG["ref"]),
-            CONFIG["repo_url"],
-            workdir,
-        ]
-    )
+        # A kept/reused runtime may hold a checkout of an older ref or another
+        # repo; sync to the requested source instead of silently running it.
+        current_url = subprocess.run(
+            ["git", "-C", workdir, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if current_url == repo_url:
+            print(f"Repo already present at {workdir}, syncing to {ref!r}.", flush=True)
+            run(["git", "-C", workdir, "fetch", "--depth", "1", "origin", ref])
+            run(["git", "-C", workdir, "checkout", "--force", "--detach", "FETCH_HEAD"])
+            return
+        print(
+            f"Repo at {workdir} tracks {current_url!r}, not {repo_url!r}; recloning.",
+            flush=True,
+        )
+        shutil.rmtree(workdir)
+    run(["git", "clone", "--depth", "1", "-b", ref, repo_url, workdir])
 
 
 def pip_install(spec, editable=False):


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

ref: N/A

## Summary

- Adds the shared plumbing for running rank_llm workloads on remote Google Colab GPUs via the [Colab CLI](https://github.com/googlecolab/google-colab-cli).
- `colab/_colab_common.sh`: bash helpers for provision (`colab new --gpu`) / exec / download / stop, with `DRY_RUN=1` support, exec retries, and kernel warmup.
- `colab/_remote_bootstrap.py`: single-file bootstrap sent to the runtime via `colab exec -f`; clones rank_llm, installs extras, runs the job, prints `ARTIFACT_PATH=` for download.
- `colab/README.md`: directory overview and offline test instructions.

## Why

PR **1/3** of a stack splitting the original Colab CLI recipes PR into smaller reviewable pieces (per maintainer feedback). This PR is the base: it contains only shared infrastructure, no runnable recipes. Nothing in the core `rank_llm` package is modified. Follow-ups: 2/3 adds the reranking recipe, 3/3 adds the training recipe. The three PRs combined are identical to the original tested branch.

## Validation

```bash
python3 -m py_compile colab/_remote_bootstrap.py
bash -n colab/_colab_common.sh
.venv/bin/pre-commit run --files colab/_remote_bootstrap.py colab/_colab_common.sh colab/README.md
```

## Follow-ups

- PR 2/3: `colab/rerank_on_colab.sh` reranking recipe + `docs/colab.md`.
- PR 3/3: `colab/train_on_colab.sh` training recipe + single-GPU accelerate config.

## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other...
    - Description: