### PR TITLE
RankLLM Repro

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -189,7 +189,7 @@ More specifically, we are interested in the `ndcg_cut_10` score for the RankZeph
 | 0.8144          | 0.7892            | 1         |
 | 0.8151          | 0.7889            | 1         |
 | 0.8144          | 0.7870            | 1         |
-| 0.7982          | 0.7763            | 1         |
+| 0.8169          | 0.7842            | 1         |
 
 
 If your result is present in the table above, please increase its frequency by 1.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -189,6 +189,7 @@ More specifically, we are interested in the `ndcg_cut_10` score for the RankZeph
 | 0.8144          | 0.7892            | 1         |
 | 0.8151          | 0.7889            | 1         |
 | 0.8144          | 0.7870            | 1         |
+| 0.7982          | 0.7763            | 1         |
 
 
 If your result is present in the table above, please increase its frequency by 1.
@@ -211,3 +212,4 @@ After editing the table above, add a log entry here as well like the previous gu
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2025-11-01 (commit [`c4d06fe`](https://github.com/castorini/rank_llm/commit/c4d06fea82763ceb5223570eb5084f480d429003))
 + Results reproduced by [@nli33](https://github.com/nli33) on 2026-03-10 (commit [`5df3ebe`](https://github.com/castorini/rank_llm/commit/5df3ebed56c9628acfc85e724bde7884f150790c))
 + Results reproduced by [@raghav-ai](https://github.com/raghav-ai) on 2026-04-03 (commit [`c1e1c84`](https://github.com/castorini/rank_llm/commit/c1e1c84d9eaad408ebfbd4b8534a29bbb9415e6a))
++ Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-07-10 (commit [`54fb0c0`](https://github.com/castorini/rank_llm/commit/54fb0c055cd1692ac75ae44cd48e1933155f99dd))

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -212,4 +212,4 @@ After editing the table above, add a log entry here as well like the previous gu
 + Results reproduced by [@aaryanshroff](https://github.com/aaryanshroff) on 2025-11-01 (commit [`c4d06fe`](https://github.com/castorini/rank_llm/commit/c4d06fea82763ceb5223570eb5084f480d429003))
 + Results reproduced by [@nli33](https://github.com/nli33) on 2026-03-10 (commit [`5df3ebe`](https://github.com/castorini/rank_llm/commit/5df3ebed56c9628acfc85e724bde7884f150790c))
 + Results reproduced by [@raghav-ai](https://github.com/raghav-ai) on 2026-04-03 (commit [`c1e1c84`](https://github.com/castorini/rank_llm/commit/c1e1c84d9eaad408ebfbd4b8534a29bbb9415e6a))
-+ Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-07-10 (commit [`54fb0c0`](https://github.com/castorini/rank_llm/commit/54fb0c055cd1692ac75ae44cd48e1933155f99dd))
++ Results reproduced by [@Quaden2307](https://github.com/Quaden2307) on 2026-07-19 (commit [`83ae542`](https://github.com/castorini/rank_llm/commit/83ae5423357136bf6a554db50bec9d564363851a))


### PR DESCRIPTION
Adds reproduction log entry for the RankLLM onboarding guide (RankZephyr + FirstMistral, DL20).

**Results**
- RankZephyr DL20 ndcg_cut_10: 0.7982
- FirstMistral DL20 ndcg_cut_10: 0.7763

**Environment**
- rank_llm @ commit 54fb0c0 (main)
- vLLM 0.24.0
- torch 2.11.0+cu128
- Python 3.12, JDK 21
- GPU: NVIDIA L4 (24GB), Google Colab Pro, driver 580.82.07 / CUDA 13.0

**Note on deviation**
Both scores are consistently below the ranges in the reproduction table (RankZephyr 0.8144–0.8201, FirstMistral 0.7829–0.7906). Since both models shifted down together, this looks like a systematic effect of the newer stack (vLLM 0.24 / torch 2.11 on current main) rather than run-to-run variance — all 486 sliding windows completed with no errors in both runs.

**Workarounds needed on a fresh install**
- Had to set a dummy `OPENAI_API_KEY` — something in the pipeline eagerly constructs an OpenAI client and crashes with "Missing credentials" even for local vLLM models (openai SDK 2.x).
- vLLM wheel required CUDA 13's `libcudart.so.13`; fixed by adding the pip-installed `nvidia/*/lib` dirs to `LD_LIBRARY_PATH`.
- Hit a JVM segfault during retrieval (Lucene MemorySegmentIndexInput); fixed with `_JAVA_OPTIONS=-Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false`.