### PR TITLE
debug: fix by setting temp to 0

### DIFF
--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -136,9 +136,13 @@ class RankListwiseOSLLM(ListwiseRankLLM):
         self._system_message = system_message
         self._is_thinking = is_thinking
         self._reasoning_token_budget = reasoning_token_budget
-        self._sampling_kwargs: dict[str, Any] | None = (
-            dict(sampling_kwargs) if sampling_kwargs else None
-        )
+        # Greedy decoding by default: without an explicit temperature the
+        # backends fall back to temperature=1.0 sampling, which scrambles
+        # generated permutations and costs ~0.02 nDCG@10 on listwise rerankers.
+        self._sampling_kwargs: dict[str, Any] = {
+            "temperature": 0.0,
+            **(sampling_kwargs or {}),
+        }
         self._output_token_estimate = None
         self._use_logits = use_logits
         self._num_gpus = num_gpus


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

ref: N/A (root-causes the score regression discussed in #412)

## Summary

- Restore greedy decoding as the default for listwise rerankers: merge `{"temperature": 0.0}` under the caller's `sampling_kwargs` in `RankListwiseOSLLM.__init__` (one hunk, +7/-3).
- Since #385 refactored sampling-parameter handling, the explicit `temperature=0` that all three backends (in-process vLLM, OpenAI-SDK/base_url, SGLang) previously passed was lost, so listwise generation silently sampled at the backend default temperature 1.0.
- Explicit user overrides via `sampling_kwargs` still win.

## Why

Every generation-based listwise run since May 18 has been stochastic instead of greedy: RankZephyr DL20 (SPLADE++ ED, top-100) dropped from the reproduction-log band 0.8144–0.8201 to ~0.796–0.797 nDCG@10 (seen in #412 on Colab and reproduced locally). Logit-based FIRST rerankers were unaffected — temperature is a monotonic scaling of logits — which explains why only RankZephyr regressed. Standalone bugfix, not part of a stack.

## Validation

```bash
.venv/bin/pre-commit run --files src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
python -m unittest discover test/rerank   # 85 tests, OK
VLLM_WORKER_MULTIPROC_METHOD=spawn python src/rank_llm/scripts/run_rank_llm.py \
  --model_path=castorini/rank_zephyr_7b_v1_full --top_k_candidates=100 --dataset=dl20 \
  --retrieval_method=SPLADE++_EnsembleDistil_ONNX \
  --prompt_template_path=src/rank_llm/rerank/prompt_templates/rank_zephyr_template.yaml \
  --context_size=4096 --variable_passages
```

A/B on the same GPU (RTX 4090) and identical SPLADE top-100 candidates:

| run | nDCG@10 |
| --- | --- |
| main (`54fb0c0`) | 0.7972 |
| main + this fix | **0.8185** |
| pre-regression code (`07d6b7f`, Apr 4) | 0.8185 (bit-identical to the fix) |

## Follow-ups


## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other...
    - Description: