### PR TITLE
docs: add Colab CLI onboarding guide (install + sanity check + RankZe…

### DIFF
--- a/colab/colab_setup.py
+++ b/colab/colab_setup.py
@@ -1,0 +1,42 @@
+"""One-time environment setup for the docs/install-colab-cli.md guide.
+
+Sent to a Colab runtime with:
+
+    colab exec -s rankllm -f colab_setup.py --timeout 3600
+
+Installs JDK 21 (needed by Pyserini/Anserini for first-stage retrieval and
+trec_eval), clones rank_llm, and installs it with the pyserini extra.
+"""
+
+import subprocess
+import sys
+
+
+def sh(cmd):
+    """Run a shell command, streaming its output back to the caller.
+
+    The Colab kernel only forwards Python-level stdout, not the OS-level
+    output of child processes, so we merge stderr into stdout and re-print
+    line by line -- otherwise errors from apt/git/pip would be invisible.
+    """
+    print(f"\n>>> {cmd}", flush=True)
+    proc = subprocess.Popen(
+        cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    for line in proc.stdout:
+        print(line, end="", flush=True)
+    if proc.wait() != 0:
+        raise SystemExit(f"command failed: {cmd}")
+
+
+sh("apt-get update -qq && apt-get install -y -qq openjdk-21-jdk-headless")
+
+# Start from a clean clone so re-running this file after a failure is safe.
+sh(
+    "rm -rf /content/rank_llm && "
+    "git clone https://github.com/castorini/rank_llm.git /content/rank_llm"
+)
+
+sh(f"{sys.executable} -m pip install -q -e '/content/rank_llm[pyserini]'")
+
+print("\nsetup ok")

--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -1,67 +1,53 @@
 # Install the Colab CLI and Rerank on a Free Colab GPU
 
-The rank_llm step of the onboarding path requires a GPU, and the
-[Google Colab CLI](https://github.com/googlecolab/google-colab-cli) is the
-easiest way to get one if you don't have suitable hardware locally: it lets you
-provision Colab GPU runtimes, run code on them, and pull results back — all
-from your own terminal, no browser notebook involved.
+The rank_llm step of the onboarding path requires a GPU, and the [Google Colab CLI](https://github.com/googlecolab/google-colab-cli) is the easiest way to get one if you don't have suitable hardware locally.
+It lets you provision Colab GPU runtimes, run code on them, and pull results back — all from your own terminal, no browser notebook involved.
 
 This guide has two parts:
 
 1. Install the Colab CLI and sanity-check it.
-2. Run your first multi-stage retrieval pipeline on a Colab GPU: BM25
-   retrieval over TREC DL20, reranked with [monoT5](https://arxiv.org/abs/2003.06713).
+2. Run your first multi-stage retrieval pipeline on a Colab GPU: BM25 retrieval over TREC DL20, reranked with [monoT5](https://arxiv.org/abs/2003.06713).
 
-Everything in this guide runs on Colab's **free tier**. The 7B listwise
-rerankers you'll meet in [onboarding.md](onboarding.md) (RankZephyr,
-FirstMistral) don't fit on the free T4 GPU — that's what the Colab Pro
-subscription discussed there is for — but the workflow you learn here is
-exactly the workflow you'll use to run them.
+Everything in this guide runs on Colab's **free tier**.
+The 7B listwise rerankers you'll meet in [onboarding.md](onboarding.md) (RankZephyr, FirstMistral) don't fit on the free T4 GPU — that's what the Colab Pro subscription discussed there is for — but the workflow you learn here is exactly the workflow you'll use to run them.
 
 Work through this guide first, then continue with [onboarding.md](onboarding.md).
-As with the previous guides in the onboarding path, don't just copy-paste your
-way through — each command below is one step of a remote-execution workflow,
-and the point is to understand what each step does.
+As with the previous guides in the onboarding path, don't just copy-paste your way through — each command below is one step of a remote-execution workflow, and the point is to understand what each step does.
 
 **Learning outcomes** for this guide:
 
 - Install and authenticate the Colab CLI.
-- Understand the session lifecycle: `colab new` → `colab exec` /
-  `colab console` → `colab download` → `colab stop`.
-- Understand the quirks of driving a remote Jupyter kernel from a terminal
-  (execution timeouts, streaming subprocess output).
-- Run an end-to-end retrieve-then-rerank pipeline (BM25 → monoT5) on TREC DL20
-  and evaluate it with nDCG@10.
+- Understand the session lifecycle: `colab new` → `colab exec` / `colab console` → `colab download` → `colab stop`.
+- Understand the quirks of driving a remote Jupyter kernel from a terminal (execution timeouts, streaming subprocess output).
+- Run an end-to-end retrieve-then-rerank pipeline (BM25 → monoT5) on TREC DL20 and evaluate it with nDCG@10.
 
 ## Part 1: Install and sanity-check the Colab CLI
 
-The CLI supports **Linux and macOS only** (no Windows). Install it with `uv`
-(or `pip install google-colab-cli` into any Python environment):
+The CLI supports **Linux and macOS only** (no Windows).
+Install it with `uv` (or `pip install google-colab-cli` into any Python environment):
 
 ```bash
 uv tool install google-colab-cli
 ```
 
-The first command that contacts Colab will walk you through authenticating
-with your Google account.
+The first command that contacts Colab will walk you through authenticating with your Google account.
 
-Now provision your first runtime. `colab new` allocates a VM and registers it
-as a named *session*; every later command addresses that session with `-s`:
+Now provision your first runtime.
+`colab new` allocates a VM and registers it as a named *session*; every later command addresses that session with `-s`:
 
 ```bash
 colab new -s sanity --gpu T4
 ```
 
-A T4 is available on the free tier (subject to availability). Check what you
-got:
+A T4 is available on the free tier (subject to availability).
+Check what you got:
 
 ```bash
 colab status -s sanity
 ```
 
-`colab exec` sends Python code to the session's Jupyter kernel — from stdin,
-or from a local `.py` file with `-f` (the file is read locally and
-transmitted; you never upload it yourself). Say hello:
+`colab exec` sends Python code to the session's Jupyter kernel — from stdin, or from a local `.py` file with `-f` (the file is read locally and transmitted; you never upload it yourself).
+Say hello:
 
 ```bash
 echo "print('hello from Colab')" | colab exec -s sanity
@@ -69,10 +55,10 @@ echo "print('hello from Colab')" | colab exec -s sanity
 
 Two quirks worth knowing before you run anything serious:
 
-- A freshly provisioned kernel sometimes drops the first connection
-  (`Connection was lost`). This is harmless — just re-run the command.
-- `colab exec` has a **30-second default timeout**. Long-running work needs an
-  explicit `--timeout` (in seconds), which you'll see in Part 2.
+- A freshly provisioned kernel sometimes drops the first connection (`Connection was lost`).
+  This is harmless — just re-run the command.
+- `colab exec` has a **30-second default timeout**.
+  Long-running work needs an explicit `--timeout` (in seconds), which you'll see in Part 2.
 
 Confirm the GPU is really there:
 
@@ -80,8 +66,8 @@ Confirm the GPU is really there:
 echo "import subprocess; print(subprocess.check_output(['nvidia-smi', '-L'], text=True))" | colab exec -s sanity
 ```
 
-You should see something like `GPU 0: Tesla T4 (UUID: ...)`. That's the whole
-sanity check — release the VM:
+You should see something like `GPU 0: Tesla T4 (UUID: ...)`.
+That's the whole sanity check — release the VM:
 
 ```bash
 colab stop -s sanity
@@ -89,18 +75,12 @@ colab stop -s sanity
 
 ## Part 2: Retrieve and rerank on a free Colab GPU
 
-You will now run a complete multi-stage retrieval pipeline on TREC DL20:
-first-stage retrieval with BM25 — the ranking function you know from the
-anserini and pyserini guides — followed by reranking the top 100 candidates
-per query with [monoT5](https://arxiv.org/abs/2003.06713), a pointwise T5
-reranker from our group. BM25 alone scores **0.4796** nDCG@10 on DL20; watch
-what the reranker does to that number.
+You will now run a complete multi-stage retrieval pipeline on TREC DL20: first-stage retrieval with BM25 — the ranking function you know from the anserini and pyserini guides — followed by reranking the top 100 candidates per query with [monoT5](https://arxiv.org/abs/2003.06713), a pointwise T5 reranker from our group.
+BM25 alone scores **0.4796** nDCG@10 on DL20; watch what the reranker does to that number.
 
-(Why not RankZephyr here? Its 7B weights alone are ~14 GB in fp16 — they
-barely fit on the free T4's 16 GB before you even allocate a KV cache. The
-listwise experiments in [onboarding.md](onboarding.md) therefore run on bigger
-GPUs via Colab Pro; monoT5-base is a couple hundred million parameters and
-runs comfortably, and the point of this guide is the workflow.)
+(Why not RankZephyr here?
+Its 7B weights alone are ~14 GB in fp16 — they barely fit on the free T4's 16 GB before you even allocate a KV cache.
+The listwise experiments in [onboarding.md](onboarding.md) therefore run on bigger GPUs via Colab Pro; monoT5-base is a couple hundred million parameters and runs comfortably, and the point of this guide is the workflow.)
 
 Provision a fresh session:
 
@@ -110,31 +90,25 @@ colab new -s rankllm --gpu T4
 
 ### Set up the environment on the VM
 
-Environment setup is boilerplate, so it's prepackaged:
-[`colab/colab_setup.py`](../colab/colab_setup.py) installs JDK 21 (Pyserini
-sits on Anserini, which is Java), clones rank_llm, and pip-installs it with
-the `pyserini` extra. Fetch it and send it to the session with an explicit
-timeout — installation takes a few minutes:
+Environment setup is boilerplate, so it's prepackaged.
+[`scripts/colab_setup.py`](../scripts/colab_setup.py) installs JDK 21 (Pyserini sits on Anserini, which is Java), clones rank_llm, and pip-installs it with the `pyserini` extra.
+Fetch it and send it to the session with an explicit timeout — installation takes a few minutes:
 
 ```bash
-curl -fsSO https://raw.githubusercontent.com/castorini/rank_llm/main/colab/colab_setup.py
+curl -fsSO https://raw.githubusercontent.com/castorini/rank_llm/main/scripts/colab_setup.py
 colab exec -s rankllm -f colab_setup.py --timeout 3600
 ```
 
-Do skim [the file](../colab/colab_setup.py) — it's ~40 lines. Beyond the three
-setup commands, the one thing it has to work around is that the Colab kernel
-only forwards *Python-level* stdout: the OS-level output of child processes
-(`apt`, `git`, `pip`) is invisible unless the script captures and re-prints
-it, which is what its small `sh()` helper does. Without that, a failing
-install would die silently and you'd have nothing to debug with.
+Do skim [the file](../scripts/colab_setup.py) — it's ~40 lines.
+Beyond the three setup commands, the one thing it has to work around is that the Colab kernel only forwards *Python-level* stdout: the OS-level output of child processes (`apt`, `git`, `pip`) is invisible unless the script captures and re-prints it, which is what its small `sh()` helper does.
+Without that, a failing install would die silently and you'd have nothing to debug with.
 
 Wait for the final `setup ok`.
 
 ### Run the pipeline, line by line
 
 The actual experiment you should run interactively, not through a wrapper.
-`colab console` drops you into a real shell on the VM (backed by tmux, so if
-your connection drops, re-running the same command reattaches to your work):
+`colab console` drops you into a real shell on the VM (backed by tmux, so if your connection drops, re-running the same command reattaches to your work):
 
 ```bash
 colab console -s rankllm
@@ -158,34 +132,23 @@ python src/rank_llm/scripts/run_rank_llm.py \
 
 Three things happen, and you'll see each in the output:
 
-1. **Retrieve** — Pyserini downloads a prebuilt Lucene index of MS MARCO v1
-   passages (~2 GB; Colab's datacenter network makes quick work of it) and
-   runs BM25 to get the top 100 passages for each DL20 query.
-2. **Rerank** — monoT5 scores every (query, passage) pair independently by
-   asking the T5 model `Query: ... Document: ... Relevant:` and reading the
-   probability of `true` vs `false` from the first generated token. This is
-   *pointwise* reranking — one passage at a time — in contrast to the
-   *listwise* rerankers in [onboarding.md](onboarding.md), which see many
-   passages at once.
-3. **Evaluate** — `trec_eval` scores the reranked run against the DL20
-   relevance judgments.
+1. **Retrieve** — Pyserini downloads a prebuilt Lucene index of MS MARCO v1 passages (~2 GB; Colab's datacenter network makes quick work of it) and runs BM25 to get the top 100 passages for each DL20 query.
+2. **Rerank** — monoT5 scores every (query, passage) pair independently by asking the T5 model `Query: ... Document: ... Relevant:` and reading the probability of `true` vs `false` from the first generated token.
+   This is *pointwise* reranking — one passage at a time — in contrast to the *listwise* rerankers in [onboarding.md](onboarding.md), which see many passages at once.
+3. **Evaluate** — `trec_eval` scores the reranked run against the DL20 relevance judgments.
 
-The whole pipeline takes under five minutes on a T4. The tail of the output
-should look like:
+The whole pipeline takes under five minutes on a T4.
+The tail of the output should look like:
 
 ```
 Results:
 ndcg_cut_10           	all	0.6771
 ```
 
-Compare that against the 0.4796 of BM25 alone: the reranker just bought ~0.20
-nDCG@10 without touching the index or the query. That gap — a cheap first
-stage to narrow the field, a smarter second stage to fix the order — is the
-whole idea of multi-stage retrieval, and everything in
-[onboarding.md](onboarding.md) builds on it.
+Compare that against the 0.4796 of BM25 alone: the reranker just bought ~0.20 nDCG@10 without touching the index or the query.
+That gap — a cheap first stage to narrow the field, a smarter second stage to fix the order — is the whole idea of multi-stage retrieval, and everything in [onboarding.md](onboarding.md) builds on it.
 
-Before leaving the VM, pack up the run artifacts (the TREC run file plus a
-JSONL with every prompt and model response), then exit the console:
+Before leaving the VM, pack up the run artifacts (the TREC run file plus a JSONL with every prompt and model response), then exit the console:
 
 ```bash
 tar czf /content/rerank_results.tar.gz -C /content/rank_llm rerank_results
@@ -194,8 +157,7 @@ exit
 
 ### Download the results and clean up
 
-Back on your machine, pull the archive, unpack it, and poke around — these
-are the same artifacts you'll be working with throughout onboarding:
+Back on your machine, pull the archive, unpack it, and poke around — these are the same artifacts you'll be working with throughout onboarding:
 
 ```bash
 colab download -s rankllm /content/rerank_results.tar.gz ./rerank_results.tar.gz
@@ -211,9 +173,7 @@ colab sessions
 
 ### Running the onboarding experiments on Colab
 
-Once you have Colab Pro (see the note in [onboarding.md](onboarding.md)), the
-RankZephyr and FirstMistral experiments run the exact same way — provision a
-bigger GPU, same setup file, then the onboarding commands in the console:
+Once you have Colab Pro (see the note in [onboarding.md](onboarding.md)), the RankZephyr and FirstMistral experiments run the exact same way — provision a bigger GPU, same setup file, then the onboarding commands in the console:
 
 ```bash
 colab new -s rankllm --gpu A100
@@ -221,18 +181,14 @@ colab exec -s rankllm -f colab_setup.py --timeout 3600
 colab console -s rankllm
 ```
 
-The listwise rerankers additionally need vLLM and the ONNX runtime (for the
-SPLADE++ first stage used there), so inside the console run
+The listwise rerankers additionally need vLLM and the ONNX runtime (for the SPLADE++ first stage used there), so inside the console run
 
 ```bash
 python -m pip install -q -e '/content/rank_llm[vllm]' onnxruntime
 ```
 
-and then the `run_rank_llm.py` commands exactly as
-[onboarding.md](onboarding.md) gives them.
+and then the `run_rank_llm.py` commands exactly as [onboarding.md](onboarding.md) gives them.
 
 ## Reproduction Log[*](https://github.com/castorini/pyserini/blob/master/docs/reproducibility.md)
 
-After completing this guide, add an entry below following the convention from
-the previous onboarding guides, and include the `ndcg_cut_10` you obtained and
-the GPU you used.
+After completing this guide, add an entry below following the convention from the previous onboarding guides, and include the `ndcg_cut_10` you obtained and the GPU you used.

--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -1,0 +1,238 @@
+# Install the Colab CLI and Rerank on a Free Colab GPU
+
+The rank_llm step of the onboarding path requires a GPU, and the
+[Google Colab CLI](https://github.com/googlecolab/google-colab-cli) is the
+easiest way to get one if you don't have suitable hardware locally: it lets you
+provision Colab GPU runtimes, run code on them, and pull results back — all
+from your own terminal, no browser notebook involved.
+
+This guide has two parts:
+
+1. Install the Colab CLI and sanity-check it.
+2. Run your first multi-stage retrieval pipeline on a Colab GPU: BM25
+   retrieval over TREC DL20, reranked with [monoT5](https://arxiv.org/abs/2003.06713).
+
+Everything in this guide runs on Colab's **free tier**. The 7B listwise
+rerankers you'll meet in [onboarding.md](onboarding.md) (RankZephyr,
+FirstMistral) don't fit on the free T4 GPU — that's what the Colab Pro
+subscription discussed there is for — but the workflow you learn here is
+exactly the workflow you'll use to run them.
+
+Work through this guide first, then continue with [onboarding.md](onboarding.md).
+As with the previous guides in the onboarding path, don't just copy-paste your
+way through — each command below is one step of a remote-execution workflow,
+and the point is to understand what each step does.
+
+**Learning outcomes** for this guide:
+
+- Install and authenticate the Colab CLI.
+- Understand the session lifecycle: `colab new` → `colab exec` /
+  `colab console` → `colab download` → `colab stop`.
+- Understand the quirks of driving a remote Jupyter kernel from a terminal
+  (execution timeouts, streaming subprocess output).
+- Run an end-to-end retrieve-then-rerank pipeline (BM25 → monoT5) on TREC DL20
+  and evaluate it with nDCG@10.
+
+## Part 1: Install and sanity-check the Colab CLI
+
+The CLI supports **Linux and macOS only** (no Windows). Install it with `uv`
+(or `pip install google-colab-cli` into any Python environment):
+
+```bash
+uv tool install google-colab-cli
+```
+
+The first command that contacts Colab will walk you through authenticating
+with your Google account.
+
+Now provision your first runtime. `colab new` allocates a VM and registers it
+as a named *session*; every later command addresses that session with `-s`:
+
+```bash
+colab new -s sanity --gpu T4
+```
+
+A T4 is available on the free tier (subject to availability). Check what you
+got:
+
+```bash
+colab status -s sanity
+```
+
+`colab exec` sends Python code to the session's Jupyter kernel — from stdin,
+or from a local `.py` file with `-f` (the file is read locally and
+transmitted; you never upload it yourself). Say hello:
+
+```bash
+echo "print('hello from Colab')" | colab exec -s sanity
+```
+
+Two quirks worth knowing before you run anything serious:
+
+- A freshly provisioned kernel sometimes drops the first connection
+  (`Connection was lost`). This is harmless — just re-run the command.
+- `colab exec` has a **30-second default timeout**. Long-running work needs an
+  explicit `--timeout` (in seconds), which you'll see in Part 2.
+
+Confirm the GPU is really there:
+
+```bash
+echo "import subprocess; print(subprocess.check_output(['nvidia-smi', '-L'], text=True))" | colab exec -s sanity
+```
+
+You should see something like `GPU 0: Tesla T4 (UUID: ...)`. That's the whole
+sanity check — release the VM:
+
+```bash
+colab stop -s sanity
+```
+
+## Part 2: Retrieve and rerank on a free Colab GPU
+
+You will now run a complete multi-stage retrieval pipeline on TREC DL20:
+first-stage retrieval with BM25 — the ranking function you know from the
+anserini and pyserini guides — followed by reranking the top 100 candidates
+per query with [monoT5](https://arxiv.org/abs/2003.06713), a pointwise T5
+reranker from our group. BM25 alone scores **0.4796** nDCG@10 on DL20; watch
+what the reranker does to that number.
+
+(Why not RankZephyr here? Its 7B weights alone are ~14 GB in fp16 — they
+barely fit on the free T4's 16 GB before you even allocate a KV cache. The
+listwise experiments in [onboarding.md](onboarding.md) therefore run on bigger
+GPUs via Colab Pro; monoT5-base is a couple hundred million parameters and
+runs comfortably, and the point of this guide is the workflow.)
+
+Provision a fresh session:
+
+```bash
+colab new -s rankllm --gpu T4
+```
+
+### Set up the environment on the VM
+
+Environment setup is boilerplate, so it's prepackaged:
+[`colab/colab_setup.py`](../colab/colab_setup.py) installs JDK 21 (Pyserini
+sits on Anserini, which is Java), clones rank_llm, and pip-installs it with
+the `pyserini` extra. Fetch it and send it to the session with an explicit
+timeout — installation takes a few minutes:
+
+```bash
+curl -sO https://raw.githubusercontent.com/castorini/rank_llm/main/colab/colab_setup.py
+colab exec -s rankllm -f colab_setup.py --timeout 3600
+```
+
+Do skim [the file](../colab/colab_setup.py) — it's ~40 lines. Beyond the three
+setup commands, the one thing it has to work around is that the Colab kernel
+only forwards *Python-level* stdout: the OS-level output of child processes
+(`apt`, `git`, `pip`) is invisible unless the script captures and re-prints
+it, which is what its small `sh()` helper does. Without that, a failing
+install would die silently and you'd have nothing to debug with.
+
+Wait for the final `setup ok`.
+
+### Run the pipeline, line by line
+
+The actual experiment you should run interactively, not through a wrapper.
+`colab console` drops you into a real shell on the VM (backed by tmux, so if
+your connection drops, re-running the same command reattaches to your work):
+
+```bash
+colab console -s rankllm
+```
+
+Inside that shell, run the pipeline:
+
+```bash
+cd /content/rank_llm
+
+# pyserini 1.2.0 constructs an OpenAI client at import time and raises if no
+# key is set -- even though BM25 retrieval never calls OpenAI. Any placeholder
+# satisfies the import; it is never actually used.
+export OPENAI_API_KEY=sk-not-a-real-key
+
+python src/rank_llm/scripts/run_rank_llm.py \
+  --model_path=castorini/monot5-base-msmarco \
+  --top_k_candidates=100 --dataset=dl20 \
+  --retrieval_method=bm25 --context_size=512
+```
+
+Three things happen, and you'll see each in the output:
+
+1. **Retrieve** — Pyserini downloads a prebuilt Lucene index of MS MARCO v1
+   passages (~2 GB; Colab's datacenter network makes quick work of it) and
+   runs BM25 to get the top 100 passages for each DL20 query.
+2. **Rerank** — monoT5 scores every (query, passage) pair independently by
+   asking the T5 model `Query: ... Document: ... Relevant:` and reading the
+   probability of `true` vs `false` from the first generated token. This is
+   *pointwise* reranking — one passage at a time — in contrast to the
+   *listwise* rerankers in [onboarding.md](onboarding.md), which see many
+   passages at once.
+3. **Evaluate** — `trec_eval` scores the reranked run against the DL20
+   relevance judgments.
+
+The whole pipeline takes under five minutes on a T4. The tail of the output
+should look like:
+
+```
+Results:
+ndcg_cut_10           	all	0.6771
+```
+
+Compare that against the 0.4796 of BM25 alone: the reranker just bought ~0.20
+nDCG@10 without touching the index or the query. That gap — a cheap first
+stage to narrow the field, a smarter second stage to fix the order — is the
+whole idea of multi-stage retrieval, and everything in
+[onboarding.md](onboarding.md) builds on it.
+
+Before leaving the VM, pack up the run artifacts (the TREC run file plus a
+JSONL with every prompt and model response), then exit the console:
+
+```bash
+tar czf /content/rerank_results.tar.gz -C /content/rank_llm rerank_results
+exit
+```
+
+### Download the results and clean up
+
+Back on your machine, pull the archive, unpack it, and poke around — these
+are the same artifacts you'll be working with throughout onboarding:
+
+```bash
+colab download -s rankllm /content/rerank_results.tar.gz ./rerank_results.tar.gz
+tar xzf rerank_results.tar.gz
+```
+
+Then release the VM and confirm nothing is left running:
+
+```bash
+colab stop -s rankllm
+colab sessions
+```
+
+### Running the onboarding experiments on Colab
+
+Once you have Colab Pro (see the note in [onboarding.md](onboarding.md)), the
+RankZephyr and FirstMistral experiments run the exact same way — provision a
+bigger GPU, same setup file, then the onboarding commands in the console:
+
+```bash
+colab new -s rankllm --gpu A100
+colab exec -s rankllm -f colab_setup.py --timeout 3600
+colab console -s rankllm
+```
+
+The listwise rerankers additionally need vLLM and the ONNX runtime (for the
+SPLADE++ first stage used there), so inside the console run
+
+```bash
+python -m pip install -q -e '/content/rank_llm[vllm]' onnxruntime
+```
+
+and then the `run_rank_llm.py` commands exactly as
+[onboarding.md](onboarding.md) gives them.
+
+## Reproduction Log[*](https://github.com/castorini/pyserini/blob/master/docs/reproducibility.md)
+
+After completing this guide, add an entry below following the convention from
+the previous onboarding guides, and include the `ndcg_cut_10` you obtained and
+the GPU you used.

--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -117,7 +117,7 @@ the `pyserini` extra. Fetch it and send it to the session with an explicit
 timeout — installation takes a few minutes:
 
 ```bash
-curl -sO https://raw.githubusercontent.com/castorini/rank_llm/main/colab/colab_setup.py
+curl -fsSO https://raw.githubusercontent.com/castorini/rank_llm/main/colab/colab_setup.py
 colab exec -s rankllm -f colab_setup.py --timeout 3600
 ```
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -9,6 +9,9 @@ In general, don't try to rush through this guide by just blindly copying and pas
 that's what I call [cargo culting](https://en.wikipedia.org/wiki/Cargo_cult_programming).
 Instead, really try to understand what's going on.
 
+The experiments in this guide require a GPU.
+Before starting, work through [install-colab-cli.md](install-colab-cli.md), which sets up the [Google Colab CLI](https://github.com/googlecolab/google-colab-cli) and has you reproduce the RankZephyr experiment from this guide on a Colab GPU, driven entirely from your terminal.
+
 **Learning outcomes** for this guide:
 
 - Understand the motivation and architecture of multi-stage retrieval.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -10,7 +10,7 @@ that's what I call [cargo culting](https://en.wikipedia.org/wiki/Cargo_cult_prog
 Instead, really try to understand what's going on.
 
 The experiments in this guide require a GPU.
-Before starting, work through [install-colab-cli.md](install-colab-cli.md), which sets up the [Google Colab CLI](https://github.com/googlecolab/google-colab-cli) and has you reproduce the RankZephyr experiment from this guide on a Colab GPU, driven entirely from your terminal.
+Before starting, work through [install-colab-cli.md](install-colab-cli.md), which sets up the [Google Colab CLI](https://github.com/googlecolab/google-colab-cli) and has you run a BM25 + monoT5 reranking pipeline on a free Colab GPU, driven entirely from your terminal.
 
 **Learning outcomes** for this guide:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,13 @@ all = [
 
 [tool.uv]
 prerelease = "allow"
+# `prerelease = "allow"` above is needed for sglang's flash-attn-4, but it also
+# lets uv pick pre-release builds of transitive dependencies. cuda-tile (pulled
+# in by vllm -> flashinfer-python) publishes release candidates whose wheel
+# matrix is incomplete: 1.6.0rc4 has no cp311 manylinux x86_64 wheel, which
+# breaks installs on Python 3.11 / Linux. Hold it to the stable line; drop this
+# once a stable 1.6.x with complete wheels is published.
+constraint-dependencies = ["cuda-tile<1.6.0rc1"]
 conflicts = [
     [{ extra = "sglang" }, { extra = "vllm" }],
     [{ extra = "sglang" }, { extra = "mcp" }],

--- a/scripts/colab_setup.py
+++ b/scripts/colab_setup.py
@@ -2,7 +2,7 @@
 
 Sent to a Colab runtime with:
 
-    colab exec -s rankllm -f colab_setup.py --timeout 3600
+    colab exec -s rankllm -f scripts/colab_setup.py --timeout 3600
 
 Installs JDK 21 (needed by Pyserini/Anserini for first-stage retrieval and
 trec_eval), clones rank_llm, and installs it with the pyserini extra.

--- a/src/rank_llm/rerank/pairwise/duot5.py
+++ b/src/rank_llm/rerank/pairwise/duot5.py
@@ -72,7 +72,14 @@ class DuoT5(PairwiseRankLLM):
         ).to(self._device)
         input_ids = tokenized["input_ids"]
 
-        outputs = self._llm.generate(input_ids, generation_config=gen_cfg)
+        # transformers>=5 only infers a missing attention mask for decoder-only
+        # models, so pass it explicitly; otherwise the encoder attends to the
+        # padding of shorter prompts in the batch and their scores degrade.
+        outputs = self._llm.generate(
+            input_ids,
+            attention_mask=tokenized["attention_mask"],
+            generation_config=gen_cfg,
+        )
         output_ids = outputs.sequences
         logits = outputs.scores
 

--- a/src/rank_llm/rerank/pointwise/monot5.py
+++ b/src/rank_llm/rerank/pointwise/monot5.py
@@ -60,9 +60,15 @@ class MonoT5(PointwiseRankLLM):
             prompts, padding=True, truncation=True, return_tensors="pt"
         ).to(self._device)
 
+        # transformers>=5 only infers a missing attention mask for decoder-only
+        # models, so pass it explicitly; otherwise the encoder attends to the
+        # padding of shorter prompts in the batch and their scores degrade.
+        attention_mask = token_prompts["attention_mask"]
         token_prompts = token_prompts["input_ids"]
 
-        batch_outputs = self._llm.generate(token_prompts, generation_config=gen_cfg)
+        batch_outputs = self._llm.generate(
+            token_prompts, attention_mask=attention_mask, generation_config=gen_cfg
+        )
 
         batch_output_ids = batch_outputs.sequences
         batch_logits = batch_outputs.scores

--- a/src/rank_llm/rerank/pointwise/monot5.py
+++ b/src/rank_llm/rerank/pointwise/monot5.py
@@ -63,8 +63,10 @@ class MonoT5(PointwiseRankLLM):
         # transformers>=5 only infers a missing attention mask for decoder-only
         # models, so pass it explicitly; otherwise the encoder attends to the
         # padding of shorter prompts in the batch and their scores degrade.
-        attention_mask = token_prompts["attention_mask"]
-        token_prompts = token_prompts["input_ids"]
+        token_prompts, attention_mask = (
+            token_prompts["input_ids"],
+            token_prompts["attention_mask"],
+        )
 
         batch_outputs = self._llm.generate(
             token_prompts, attention_mask=attention_mask, generation_config=gen_cfg


### PR DESCRIPTION
# PR description (branch: docs/install-colab-cli)

> expected score (0.6771) assumes the monoT5 attention-mask fix is on main.

# Pull Request Checklist

## Reference Issue

ref: N/A (supersedes #407 / #408 / #409 per professor's feedback)

## Summary

- Adds `docs/install-colab-cli.md`: a lightweight onboarding guide in the style of the anserini/pyserini onboarding sequence — (1) install the [Colab CLI](https://github.com/googlecolab/google-colab-cli) and sanity-check it, (2) run an end-to-end multi-stage retrieval pipeline (BM25 → monoT5-base rerank, TREC DL20) — **entirely on Colab's free tier** (T4).
- Students type each `colab` command themselves (`new` → `exec` / `console` → `download` → `stop`); the core experiment runs line-by-line in an interactive `colab console` shell. Only environment setup is prepackaged (`scripts/colab_setup.py`, fetched with curl and sent via `colab exec -f`).
- Expected result: nDCG@10 0.4796 (BM25) → **0.6771** (monoT5-base rerank) — the multi-stage lift is the pedagogical payoff. Guide ends with a Reproduction Log section like the previous onboarding guides.
- Adds a two-line pointer at the top of `docs/onboarding.md` (intended sequence: `install-colab-cli.md` → `onboarding.md`). A closing section shows how to run the onboarding RankZephyr/FirstMistral experiments the same way once students have Colab Pro (7B models don't fit the free T4).

## Why

Maintainer feedback on the recipes stack (#407–#409) asked for something much more lightweight: a doc students follow and reproduce before onboarding, like the anserini/pyserini sequence, rather than wrapped one-command automation. Free tier keeps the entry cost at zero (Colab Pro only becomes necessary at the onboarding.md step, as that guide already explains). The hard-won details from the recipes (JDK 21, exec timeouts, streaming child-process output, the pyserini import-time `OPENAI_API_KEY` quirk) survive as inline explanations.

## Validation

```bash
.venv/bin/pre-commit run --files docs/install-colab-cli.md scripts/colab_setup.py docs/onboarding.md
python3 -m py_compile scripts/colab_setup.py
```

Live end-to-end pass on an actual free-tier T4 via the Colab CLI (with the attention-mask fix applied):
- `colab new -s ... --gpu T4` → `colab exec -f scripts/colab_setup.py` → `setup ok`
- piped `colab console` smoke test (real shell on the VM confirmed)
- full BM25 → monoT5 → trec_eval pipeline on the VM in 230 s total: nDCG@1/5/10 = 0.8210/0.7045/0.6771, matching the local RTX 4090 run bit-for-bit
- `colab download` of the artifact tarball and `colab stop` cleanup verified
- BM25 baseline re-derived from the retrieval cache: 0.4796

## Checklist Items

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Reproduction logs
- [ ] Other...

---

# Close comment for #407 (feat/colab-cli-1-common)

Per feedback, replacing this scripts-based stack with a lightweight onboarding doc: #<NEW_PR> adds `docs/install-colab-cli.md` (install + sanity check + a free-tier BM25 → monoT5 repro, in the style of the anserini/pyserini onboarding sequence). The shared plumbing here is preserved on the branch in case we later want one-command automation on top of the doc flow. Closing.

# Close comment for #408 (feat/colab-cli-2-rerank)

Superseded by the lightweight doc approach in #<NEW_PR> — the reranking flow there is the same idea this recipe automated, but as step-by-step commands students run themselves (and sized to the free tier). Branch preserved. Closing.

# Close comment for #409 (feat/colab-cli-3-train)

Superseded by the lightweight doc approach in #<NEW_PR>, which covers the onboarding use case. The training recipe and single-GPU accelerate config are out of scope for that doc; branch preserved if remote training comes back later. Closing.