### PR TITLE
docs: fix colab-cli install (pin jupyter-kernel-client) and add repro…

### DIFF
--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -27,7 +27,10 @@ The CLI supports **Linux and macOS only** (no Windows).
 Install it with `uv` (or `pip install google-colab-cli` into any Python environment):
 
 ```bash
-uv tool install google-colab-cli
+# jupyter-kernel-client 1.0.0 renamed KernelClient, which google-colab-cli 0.6.0
+# still imports, so a default install crashes on the first `colab exec`. Pin
+# below 1.0.0 until the CLI is updated upstream.
+uv tool install google-colab-cli --with "jupyter-kernel-client<1.0.0"
 ```
 
 The first command that contacts Colab will walk you through authenticating with your Google account.
@@ -219,3 +222,5 @@ Go to [the RankZephyr guide](onboarding-rz.md) next.
 ## Reproduction Log[*](https://github.com/castorini/pyserini/blob/master/docs/reproducibility.md)
 
 After completing this guide, add an entry below following the convention from the previous onboarding guides, and include the `ndcg_cut_10` you obtained and the GPU you used.
+
+Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-06 (commit [`e2ceebe`](https://github.com/castorini/rank_llm/commit/e2ceebe68126430c0960f7282e14c709865d66cb)), ndcg_cut_10 = 0.6771 on a Colab free-tier T4.

--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -24,7 +24,7 @@ As with the previous guides in the onboarding path, don't just copy-paste your w
 ## Install and Sanity-Check the Colab CLI
 
 The CLI supports **Linux and macOS only** (no Windows).
-Install it with `uv` (or `pip install google-colab-cli` into any Python environment):
+Install it with `uv` (or `pip install "google-colab-cli" "jupyter-kernel-client<1.0.0"` into any Python environment):
 
 ```bash
 # jupyter-kernel-client 1.0.0 renamed KernelClient, which google-colab-cli 0.6.0

--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -232,4 +232,4 @@ If your result is not present, add a new row (in sorted order) to the table with
 
 After editing the table above, add a log entry here as well like the previous guides:
 
-+ Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-06 (commit [`e2ceebe`](https://github.com/castorini/rank_llm/commit/e2ceebe68126430c0960f7282e14c709865d66cb)) on a free-tier T4
++ Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-06 (commit [`e2ceebe`](https://github.com/castorini/rank_llm/commit/e2ceebe68126430c0960f7282e14c709865d66cb))

--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -221,6 +221,15 @@ Go to [the RankZephyr guide](onboarding-rz.md) next.
 
 ## Reproduction Log[*](https://github.com/castorini/pyserini/blob/master/docs/reproducibility.md)
 
-After completing this guide, add an entry below following the convention from the previous onboarding guides, and include the `ndcg_cut_10` you obtained and the GPU you used.
+After completing this guide, add your `ndcg_cut_10` to the table below, then add a log entry beneath it following the convention from the previous onboarding guides.
 
-Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-06 (commit [`e2ceebe`](https://github.com/castorini/rank_llm/commit/e2ceebe68126430c0960f7282e14c709865d66cb)), ndcg_cut_10 = 0.6771 on a Colab free-tier T4.
+| monoT5 DL20 | Frequency |
+|-------------|-----------|
+| 0.6771      | 1         |
+
+If your result is present in the table above, please increase its frequency by 1.
+If your result is not present, add a new row (in sorted order) to the table with frequency 1.
+
+After editing the table above, add a log entry here as well like the previous guides:
+
++ Results reproduced by [@dawoodkhandev](https://github.com/dawoodkhandev) on 2026-08-06 (commit [`e2ceebe`](https://github.com/castorini/rank_llm/commit/e2ceebe68126430c0960f7282e14c709865d66cb)) on a free-tier T4


### PR DESCRIPTION
## Reference Issue

ref: N/A (requested by Prof. Lin in the DSG Slack after I tested the Colab CLI onboarding guide)

## Summary

A fresh `uv tool install google-colab-cli` pulls jupyter-kernel-client 1.0.0, which renamed `KernelClient`. google-colab-cli 0.6.0 still imports the old name, so the first `colab exec` crashes with `AttributeError: module 'jupyter_kernel_client' has no attribute 'KernelClient'`. This makes install-colab-cli.md fail out of the box on a clean install.

This pins `jupyter-kernel-client<1.0.0` in the install command (with a comment explaining why) until google-colab-cli is updated upstream. Also adds a reproduction log entry.

## Why

The install step is the first thing a new URA runs in this guide, and it currently crashes before they reach the actual pipeline. The root cause is upstream in google-colab-cli, but pinning here unblocks the guide immediately.

## Validation

Ran the full guide end to end on a free-tier Colab T4 after applying the pin:

- `colab exec` sanity check passed (GPU confirmed as Tesla T4)
- BM25 → monoT5 pipeline on DL20 reproduced the target exactly: `ndcg_cut_10 = 0.6771`

## Follow-ups

- The proper long-term fix is upstream in google-colab-cli (update it to the renamed client class); the pin can be removed once that lands.

## Checklist Items

- [x] Have you followed the contributing guidelines?
- [x] Have you verified that there are no existing Pull Requests for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [x] Documentation content changes
- [x] Reproduction logs
- [ ] Other...