### PR TITLE
Add Colab CLI reranking recipe with CUDA 12.8 fixes

### DIFF
--- a/colab/README.md
+++ b/colab/README.md
@@ -1,0 +1,114 @@
+# rank_llm on Google Colab (Colab CLI recipes)
+
+Self-contained recipes that drive the [Google Colab CLI](https://github.com/googlecolab/google-colab-cli)
+to run rank_llm **reranking** on a remote Colab GPU, then download the results
+to your machine. Nothing in the core `rank_llm` package is modified —
+everything lives in this directory.
+
+Full docs: [`../docs/colab.md`](../docs/colab.md).
+
+## What's here
+
+| File | Purpose |
+| --- | --- |
+| `rerank_on_colab.sh` | Local orchestrator: provision GPU → `rank-llm rerank` → download `results.jsonl` + `results.trec` `.tar.gz`. |
+| `_remote_bootstrap.py` | Sent to the runtime by `colab exec -f`. Clones rank_llm, installs extras, runs the job, prints `ARTIFACT_PATH=`. |
+| `_colab_common.sh` | Shared bash helpers (provision / exec / download / DRY_RUN). |
+
+## Features
+
+- **Reranking has two modes**:
+  - `dataset` (default) — end-to-end on a built-in benchmark (e.g. `dl19`) via a
+    Pyserini prebuilt index; self-contained (installs JDK 21 + pyserini remotely).
+  - `requests_url` — rerank-only over a candidates JSONL fetched from an http URL.
+- **Everything is env-var configurable** (GPU, model, dataset, …) —
+  see the tables in [`../docs/colab.md`](../docs/colab.md).
+- **`DRY_RUN=1`** prints the exact `colab` commands instead of executing them, so
+  you can verify parameters without spending GPU time.
+- **Single `.tar.gz` artifacts** — output dirs are tarred remotely so a directory
+  download is a single clean file.
+
+## How it works
+
+`colab exec` only transmits **one** file and can't pass argv. So each orchestrator
+builds a temp bootstrap file = an injected `CONFIG = json.loads(...)` line
+prepended to `_remote_bootstrap.py`, and sends that. The runtime script then
+clones rank_llm, `pip install`s the right extras, runs the command, and prints
+`ARTIFACT_PATH=<remote .tar.gz>` on its last line for the caller to `colab download`.
+
+## Manual testing
+
+### A. Offline checks (no Colab account, no GPU spend)
+
+These verify syntax and the exact commands that *would* run:
+
+```bash
+# 1. The remote bootstrap compiles
+python3 -m py_compile colab/_remote_bootstrap.py
+
+# 2. Shell scripts parse
+bash -n colab/rerank_on_colab.sh colab/_colab_common.sh
+
+# 3. Optional: lint (no pip needed)
+uv tool run --from shellcheck-py shellcheck -x colab/*.sh
+
+# 4. Inspect the generated colab command sequence + injected params
+DRY_RUN=1 bash colab/rerank_on_colab.sh
+DRY_RUN=1 RERANK_MODE=requests_url REQUESTS_URL=https://example.com/c.jsonl \
+  bash colab/rerank_on_colab.sh
+```
+
+In the `DRY_RUN` output, confirm the order is **provision → exec → download** and
+that your env-var overrides appear in the injected `CONFIG`.
+
+You can also preview the exact file that gets sent to the runtime:
+
+```bash
+# prints the temp bootstrap path; cat it to see the injected CONFIG = json.loads(...)
+DRY_RUN=1 bash -x colab/rerank_on_colab.sh 2>&1 | grep -i bootstrap
+```
+
+### B. Live checks (needs a Google account; provisions a paid GPU)
+
+Prereq — install and authenticate the CLI once (Linux/macOS only):
+
+```bash
+uv tool install git+https://github.com/googlecolab/google-colab-cli
+# then authenticate per the CLI's prompts
+```
+
+> GPU access depends on your Colab plan: a **free** account is usually limited to
+> **T4**; `L4`/`A100`/`H100` need Colab Pro/Pro+. "Backend rejected accelerator"
+> means you lack quota for that tier.
+
+**Reranking (cheapest smoke test, ~minutes):**
+
+```bash
+# Pro/Pro+ (≥24 GB) — the default 7B listwise reranker:
+GPU=A100 bash colab/rerank_on_colab.sh
+# -> ./colab_runs/colab_rerank_out.tar.gz  (results.jsonl + results.trec)
+
+# Free tier (T4) — the 7B model OOMs on 16 GB, so use a small pointwise model.
+# bm25 retrieval is the most reliable (pure Lucene, no ONNX deps):
+GPU=T4 MODEL_PATH=castorini/monot5-base-msmarco-10k RETRIEVAL_METHOD=bm25 \
+  bash colab/rerank_on_colab.sh
+
+# dataset mode auto-evaluates: nDCG@1/5/10 print in the terminal during the run.
+tar xzf colab_runs/colab_rerank_out.tar.gz -C colab_runs   # results.jsonl + results.trec
+```
+
+(The default `SPLADE++_EnsembleDistil_ONNX` also works — the recipe auto-installs
+`onnxruntime` for it — but it downloads a learned-sparse index + ONNX encoder, so
+`bm25` is the quicker, more robust first demo.)
+
+The recipe creates a named session (`rankllm-rerank`), runs, downloads the
+artifact, and **stops the runtime automatically**. Set `KEEP_SESSION=1` to leave
+it running for debugging (`colab exec -s NAME`, `colab sessions`, then
+`colab stop -s NAME`). `colab exec` has a 30s default timeout, so the recipe
+raises it via `EXEC_TIMEOUT` (default 1h) — bump it for larger jobs.
+
+## Using with an agent
+
+The Colab CLI ships `COLAB_SKILL.md`. With it loaded, an assistant can map a
+request like *"rerank dl19 with RankZephyr on an A100"* to
+`GPU=A100 bash colab/rerank_on_colab.sh`.

--- a/colab/_colab_common.sh
+++ b/colab/_colab_common.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Shared helpers for the rank_llm Colab CLI recipes.
+# Sourced by train_on_colab.sh and rerank_on_colab.sh.
+#
+# Real Colab CLI surface these wrap (see `colab -h`):
+#   colab new   --gpu A100 -s NAME        provision a named session
+#   colab exec  -f FILE -s NAME --timeout N   run a file in that session
+#   colab download REMOTE LOCAL -s NAME   pull an artifact back
+#   colab stop  -s NAME                    release the runtime
+
+COLAB_BIN="${COLAB_BIN:-colab}"
+COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_PY="$COMMON_DIR/_remote_bootstrap.py"
+
+# Run a `colab` subcommand, or just print it when DRY_RUN=1.
+run_colab() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    printf '[dry-run] %s' "$COLAB_BIN"
+    printf ' %q' "$@"
+    printf '\n'
+  else
+    "$COLAB_BIN" "$@"
+  fi
+}
+
+# Fail early with an install hint if the CLI is missing (skipped in dry-run).
+require_colab() {
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    return 0
+  fi
+  if ! command -v "$COLAB_BIN" >/dev/null 2>&1; then
+    echo "error: '$COLAB_BIN' not found." >&2
+    echo "Install it with: uv tool install git+https://github.com/googlecolab/google-colab-cli" >&2
+    exit 1
+  fi
+}
+
+# Build a temp bootstrap file: an injected `CONFIG = json.loads(...)` line
+# prepended to _remote_bootstrap.py. Echoes the temp file path.
+build_bootstrap() {
+  local cfg_json="$1"
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/rankllm_colab_bootstrap.XXXXXX.py")"
+  {
+    printf 'import json\nCONFIG = json.loads(r"""%s""")\n' "$cfg_json"
+    cat "$BOOTSTRAP_PY"
+  } >"$tmp"
+  printf '%s\n' "$tmp"
+}
+
+# Create a named session with the requested accelerator.
+provision_gpu() {
+  local gpu="$1" session="$2"
+  echo "==> Creating Colab session '$session' (--gpu $gpu)"
+  run_colab new --gpu "$gpu" -s "$session"
+}
+
+# Run `colab exec -f FILE` with retries. A freshly-READY kernel often drops the
+# first websocket connection ("Connection was lost"), and long-held sockets can
+# drop mid-run; the bootstrap is idempotent (clone skips if present), so retrying
+# is safe. Tunable via EXEC_RETRIES / EXEC_RETRY_WAIT.
+colab_exec_file() {
+  local file="$1" session="$2" timeout="$3"
+  local attempts="${EXEC_RETRIES:-3}" wait="${EXEC_RETRY_WAIT:-15}" n=1
+  while true; do
+    if run_colab exec -f "$file" -s "$session" --timeout "$timeout"; then
+      return 0
+    fi
+    if ((n >= attempts)); then
+      echo "error: 'colab exec' failed after ${attempts} attempt(s)." >&2
+      return 1
+    fi
+    echo "   exec attempt ${n}/${attempts} failed; retrying in ${wait}s..." >&2
+    sleep "$wait"
+    n=$((n + 1))
+  done
+}
+
+# Poke the kernel with a trivial cell so the websocket stabilizes before the real
+# (long) exec. This absorbs the common post-READY "Connection was lost" race.
+warmup_kernel() {
+  local session="$1" tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/rankllm_warmup.XXXXXX.py")"
+  printf 'print("kernel warmup ok")\n' >"$tmp"
+  echo "==> Warming up kernel on '$session'"
+  colab_exec_file "$tmp" "$session" 30
+  local rc=$?
+  rm -f "$tmp"
+  return $rc
+}
+
+# The default exec timeout is 30s, far too short for installs + model runs, so
+# callers pass a large value. Retries are handled by colab_exec_file.
+exec_bootstrap() {
+  local tmp="$1" session="$2" timeout="$3"
+  echo "==> Executing remote bootstrap on '$session' (timeout ${timeout}s)"
+  colab_exec_file "$tmp" "$session" "$timeout"
+}
+
+# Download a single remote artifact (a .tar.gz) into a local directory.
+download_artifact() {
+  local remote="$1" local_dir="$2" session="$3"
+  local fname
+  fname="$(basename "$remote")"
+  echo "==> Downloading $remote -> $local_dir/$fname"
+  if [[ "${DRY_RUN:-0}" != "1" ]]; then
+    mkdir -p "$local_dir"
+  fi
+  run_colab download "$remote" "$local_dir/$fname" -s "$session"
+  echo "Done. Unpack with: tar xzf $local_dir/$fname -C $local_dir"
+}
+
+# Release the runtime (skipped when KEEP_SESSION=1 so you can debug via
+# `colab exec -s NAME`). Tolerates a missing session.
+stop_session() {
+  local session="$1"
+  if [[ "${KEEP_SESSION:-0}" == "1" ]]; then
+    echo "==> KEEP_SESSION=1, leaving session '$session' running (stop with: colab stop -s $session)"
+    return 0
+  fi
+  echo "==> Stopping Colab session '$session'"
+  run_colab stop -s "$session" || true
+}

--- a/colab/_remote_bootstrap.py
+++ b/colab/_remote_bootstrap.py
@@ -1,0 +1,330 @@
+"""Remote bootstrap executed on a Google Colab runtime via ``colab exec -f``.
+
+This file is sent verbatim to a provisioned Colab kernel by the local
+orchestration scripts (``train_on_colab.sh`` / ``rerank_on_colab.sh``).
+
+``colab exec`` only transmits a single file and provides no way to pass argv,
+so the orchestration script prepends a line of the form::
+
+    CONFIG = {"mode": "train", "base_model": "...", ...}
+
+before the contents of this file and executes the concatenation. The merge
+below lets that injected dict override the defaults while keeping this file
+independently importable / lintable (``CONFIG`` is always defined).
+
+The script clones rank_llm, installs the right extras, runs the requested
+training or reranking command, and prints ``ARTIFACT_PATH=<remote path>`` on
+the last line so the caller knows what to ``colab download``.
+"""
+
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
+DEFAULT_CONFIG = {
+    # Common
+    "mode": "train",  # "train" | "rerank"
+    "repo_url": "https://github.com/castorini/rank_llm.git",
+    "ref": "main",
+    "workdir": "/content/rank_llm",
+    "install_flash_attn": False,
+    # Training
+    "base_model": "HuggingFaceH4/zephyr-7b-beta",
+    "train_dataset_path": "rryisthebest/rank_zephyr_training_data_alpha",
+    "objective": "generation",  # generation | ranking | combined
+    "output_dir": "/content/rank_llm/training/models/colab_run",
+    "num_train_epochs": 1,
+    "per_device_train_batch_size": 1,
+    "gradient_accumulation_steps": 16,
+    "num_warmup_steps": 10,
+    "lr_scheduler_type": "cosine",
+    "seed": 42,
+    "extra_train_args": [],  # e.g. ["--ranking_loss", "ranknet", "--weighted"]
+    # Reranking
+    "model_path": "castorini/rank_zephyr_7b_v1_full",
+    "rerank_mode": "dataset",  # "dataset" | "requests_url"
+    "dataset": "dl19",
+    "retrieval_method": "SPLADE++_EnsembleDistil_ONNX",
+    "requests_url": "",  # used when rerank_mode == "requests_url"
+    "top_k": 100,
+    "context_size": 4096,
+    "num_gpus": 1,
+    "install_pyserini": True,  # needed for dataset-mode retrieval (JDK 21)
+    "extra_rerank_args": [],
+}
+
+# The orchestration script may inject a partial ``CONFIG`` before this file;
+# merge it over the defaults. Accessing via ``globals()`` keeps this valid when
+# the file is run standalone (no injection) so linters/py_compile stay happy.
+CONFIG = {**DEFAULT_CONFIG, **globals().get("CONFIG", {})}
+
+
+def run(cmd, cwd=None, env=None):
+    """Run a command, streaming its output; raise on non-zero exit.
+
+    Colab's kernel only surfaces the Python ``sys.stdout``, not a child
+    process's OS-level stdout/stderr. So we merge the child's streams and
+    re-print them through ``print`` line by line — otherwise subprocess errors
+    (which go to stderr) are invisible in the ``colab exec`` output.
+    """
+    printable = cmd if isinstance(cmd, str) else shlex.join(cmd)
+    print(f"\n>>> {printable}", flush=True)
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        shell=isinstance(cmd, str),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    for line in proc.stdout:
+        print(line, end="", flush=True)
+    proc.wait()
+    if proc.returncode != 0:
+        raise SystemExit(f"Command failed (exit {proc.returncode}): {printable}")
+
+
+def clone_repo():
+    workdir = CONFIG["workdir"]
+    repo_url = CONFIG["repo_url"]
+    ref = str(CONFIG["ref"])
+    if os.path.isdir(os.path.join(workdir, ".git")):
+        # A kept/reused runtime may hold a checkout of an older ref or another
+        # repo; sync to the requested source instead of silently running it.
+        current_url = subprocess.run(
+            ["git", "-C", workdir, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if current_url == repo_url:
+            print(f"Repo already present at {workdir}, syncing to {ref!r}.", flush=True)
+            run(["git", "-C", workdir, "fetch", "--depth", "1", "origin", ref])
+            run(["git", "-C", workdir, "checkout", "--force", "--detach", "FETCH_HEAD"])
+            return
+        print(
+            f"Repo at {workdir} tracks {current_url!r}, not {repo_url!r}; recloning.",
+            flush=True,
+        )
+        shutil.rmtree(workdir)
+    run(["git", "clone", "--depth", "1", "-b", ref, repo_url, workdir])
+
+
+def pip_install(spec, editable=False):
+    cmd = [sys.executable, "-m", "pip", "install", "-q"]
+    if editable:
+        cmd.append("-e")
+    cmd.append(spec)
+    run(cmd)
+
+
+def install_apt_jdk21():
+    # rank_llm retrieval (pyserini/anserini) requires JDK 21.
+    run("apt-get update -qq && apt-get install -y -qq openjdk-21-jdk-headless")
+
+
+def archive(path):
+    """Tar a result directory into a single file for a clean `colab download`."""
+    path = path.rstrip("/")
+    tar = path + ".tar.gz"
+    parent = os.path.dirname(path) or "."
+    base = os.path.basename(path)
+    run(["tar", "czf", tar, "-C", parent, base])
+    return tar
+
+
+def do_train():
+    clone_repo()
+    workdir = CONFIG["workdir"]
+    pip_install(f"{workdir}[training]", editable=True)
+    if CONFIG["install_flash_attn"]:
+        run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-q",
+                "flash-attn",
+                "--no-build-isolation",
+            ]
+        )
+
+    output_dir = CONFIG["output_dir"]
+    os.makedirs(output_dir, exist_ok=True)
+
+    env = dict(os.environ)
+    env["DS_SKIP_CUDA_CHECK"] = "1"
+    env["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+    cmd = [
+        "accelerate",
+        "launch",
+        "--config_file",
+        "configs/accel_config_single_gpu.yaml",
+        "train_rankllm.py",
+        "--model_name_or_path",
+        str(CONFIG["base_model"]),
+        "--train_dataset_path",
+        str(CONFIG["train_dataset_path"]),
+        "--objective",
+        str(CONFIG["objective"]),
+        "--num_train_epochs",
+        str(CONFIG["num_train_epochs"]),
+        "--per_device_train_batch_size",
+        str(CONFIG["per_device_train_batch_size"]),
+        "--gradient_accumulation_steps",
+        str(CONFIG["gradient_accumulation_steps"]),
+        "--num_warmup_steps",
+        str(CONFIG["num_warmup_steps"]),
+        "--lr_scheduler_type",
+        str(CONFIG["lr_scheduler_type"]),
+        "--seed",
+        str(CONFIG["seed"]),
+        "--gradient_checkpointing",
+        "--low_cpu_mem_usage",
+        "--output_dir",
+        output_dir,
+        "--checkpointing_steps",
+        "epoch",
+    ]
+    cmd += [str(a) for a in CONFIG["extra_train_args"]]
+    run(cmd, cwd=os.path.join(workdir, "training"), env=env)
+    return archive(output_dir)
+
+
+
+def pin_vllm_cuda128():
+    """Install a CUDA 12.8-matched vLLM + torch.
+
+    Colab GPU images ship CUDA toolkit 12.8, but recent vLLM wheels are built
+    against CUDA 13 (they load ``libcudart.so.13``), so a default
+    ``pip install vllm`` crashes on import with::
+
+        ImportError: libcudart.so.13: cannot open shared object file
+
+    Pinning vllm==0.11.0 + torch==2.8.0 from the cu128 index gives a matched,
+    CUDA 12.8-compatible pair. transformers is pinned to the 4.55.x line that
+    vLLM 0.11.0 targets; newer transformers break vLLM's TokenizersBackend with
+    ``TokenizersBackend has no attribute all_special_tokens_extended``.
+    """
+    run([
+        sys.executable, "-m", "pip", "install", "-q", "--force-reinstall",
+        "vllm==0.11.0", "torch==2.8.0",
+        "--extra-index-url", "https://download.pytorch.org/whl/cu128",
+    ])
+    run([sys.executable, "-m", "pip", "install", "-q", "transformers==4.55.4"])
+
+
+def ensure_dl_qrels(dataset):
+    """Pre-seed the qrels file pyserini's evaluator needs.
+
+    pyserini's Java evaluator downloads qrels from a hardcoded anserini-tools
+    URL that now 404s, so dataset-mode eval fails with::
+
+        java.io.IOException: Error downloading topics from .../qrels.{dataset}-passage.txt
+
+    We fetch the authoritative qrels from NIST into pyserini's cache dir so the
+    evaluator finds it locally instead of trying the dead URL. Best-effort:
+    only handles the TREC DL passage sets.
+    """
+    nist = {
+        "dl19": "https://trec.nist.gov/data/deep/2019qrels-pass.txt",
+        "dl20": "https://trec.nist.gov/data/deep/2020qrels-pass.txt",
+    }
+    url = nist.get(str(dataset).lower())
+    if not url:
+        return
+    cache = os.path.expanduser("~/.cache/pyserini/topics-and-qrels")
+    os.makedirs(cache, exist_ok=True)
+    dst = os.path.join(cache, f"qrels.{dataset}-passage.txt")
+    if os.path.exists(dst) and os.path.getsize(dst) > 0:
+        return
+    run(["curl", "-sL", "-A", "Mozilla/5.0", "-o", dst, url])
+
+
+def do_rerank():
+    clone_repo()
+    workdir = CONFIG["workdir"]
+    pyserini = CONFIG["install_pyserini"] and CONFIG["rerank_mode"] == "dataset"
+    spec = f"{workdir}[vllm,pyserini]" if pyserini else f"{workdir}[vllm]"
+    if pyserini:
+        install_apt_jdk21()
+    pip_install(spec, editable=True)
+    # Re-pin vllm/torch to a CUDA 12.8-matched pair (Colab ships CUDA 12.8 but
+    # default vllm wheels need CUDA 13). Must run after the extras install so it
+    # wins the final resolution.
+    pin_vllm_cuda128()
+    # ONNX learned-sparse retrievers (e.g. SPLADE++_EnsembleDistil_ONNX) need
+    # onnxruntime for the query encoder; the pyserini extra does not pull it in.
+    if pyserini and "onnx" in str(CONFIG["retrieval_method"]).lower():
+        pip_install("onnxruntime")
+    # Pre-seed qrels so pyserini's evaluator doesn't hit the dead download URL.
+    if pyserini and CONFIG["rerank_mode"] == "dataset":
+        ensure_dl_qrels(CONFIG["dataset"])
+
+    out_dir = os.path.join(workdir, "colab_rerank_out")
+    os.makedirs(out_dir, exist_ok=True)
+    out_jsonl = os.path.join(out_dir, "results.jsonl")
+    out_trec = os.path.join(out_dir, "results.trec")
+
+    cmd = [
+        "rank-llm",
+        "rerank",
+        "--model-path",
+        str(CONFIG["model_path"]),
+        "--num-gpus",
+        str(CONFIG["num_gpus"]),
+        "--context-size",
+        str(CONFIG["context_size"]),
+        "--output-jsonl-file",
+        out_jsonl,
+        "--output-trec-file",
+        out_trec,
+    ]
+
+    if CONFIG["rerank_mode"] == "requests_url":
+        req_file = os.path.join(out_dir, "requests.jsonl")
+        run(["wget", "-q", "-O", req_file, str(CONFIG["requests_url"])])
+        cmd += ["--requests-file", req_file]
+    else:
+        cmd += [
+            "--dataset",
+            str(CONFIG["dataset"]),
+            "--retrieval-method",
+            str(CONFIG["retrieval_method"]),
+            "--top-k-candidates",
+            str(CONFIG["top_k"]),
+        ]
+
+    cmd += [str(a) for a in CONFIG["extra_rerank_args"]]
+    # Unbuffered so the child's stdout (model/retrieval progress) is interleaved
+    # with stderr in real time instead of being lost if the process crashes.
+    env = dict(os.environ)
+    env["PYTHONUNBUFFERED"] = "1"
+    # pyserini 1.2.0 eagerly builds an ``openai.OpenAI()`` client at import time
+    # (pyserini/encode/_openai.py). With openai>=2 that raises when no key is set
+    # — even for bm25 retrieval that never touches OpenAI. A placeholder lets the
+    # import succeed; the client is never actually called. A real key is kept.
+    env.setdefault("OPENAI_API_KEY", "sk-pyserini-import-placeholder")
+    run(cmd, cwd=workdir, env=env)
+    return archive(out_dir)
+
+
+def main():
+    mode = CONFIG["mode"]
+    if mode == "train":
+        artifact = do_train()
+    elif mode == "rerank":
+        artifact = do_rerank()
+    else:
+        raise SystemExit(f"Unknown mode: {mode!r} (expected 'train' or 'rerank')")
+    # Last line is parsed by the orchestration script for `colab download`.
+    print(f"\nARTIFACT_PATH={artifact}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/colab/rerank_on_colab.sh
+++ b/colab/rerank_on_colab.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Run rank_llm listwise reranking on a remote Google Colab GPU runtime via the
+# Colab CLI. Provisions a GPU, clones rank_llm, installs the vLLM inference
+# extras, runs `rank-llm rerank`, and downloads the results as a .tar.gz
+# (results.jsonl + results.trec).
+#
+# Two modes:
+#   RERANK_MODE=dataset       (default) end-to-end on a built-in benchmark
+#                             (e.g. dl19) using a Pyserini prebuilt index.
+#                             Fully self-contained; installs JDK 21 + pyserini.
+#   RERANK_MODE=requests_url  rerank-only over a candidates JSONL fetched from
+#                             REQUESTS_URL (HF/GCS/any http). No retrieval.
+#
+# In requests_url mode the candidates JSONL is fetched over http from inside the
+# runtime, so host it at a reachable URL. See docs/colab.md.
+#
+# Usage:
+#   bash colab/rerank_on_colab.sh                       # dl19 dataset demo
+#   RERANK_MODE=requests_url REQUESTS_URL=https://.../cands.jsonl \
+#     bash colab/rerank_on_colab.sh
+#   DRY_RUN=1 bash colab/rerank_on_colab.sh             # print colab commands
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=colab/_colab_common.sh
+source "$SCRIPT_DIR/_colab_common.sh"
+
+# --- Configurable knobs (env vars) ------------------------------------------
+GPU="${GPU:-A100}"
+SESSION="${SESSION:-rankllm-rerank}"
+EXEC_TIMEOUT="${EXEC_TIMEOUT:-3600}"
+REPO_URL="${REPO_URL:-https://github.com/castorini/rank_llm.git}"
+REF="${REF:-main}"
+WORKDIR="${WORKDIR:-/content/rank_llm}"
+MODEL_PATH="${MODEL_PATH:-castorini/rank_zephyr_7b_v1_full}"
+RERANK_MODE="${RERANK_MODE:-dataset}"
+DATASET="${DATASET:-dl19}"
+RETRIEVAL_METHOD="${RETRIEVAL_METHOD:-SPLADE++_EnsembleDistil_ONNX}"
+REQUESTS_URL="${REQUESTS_URL:-}"
+TOP_K="${TOP_K:-100}"
+CONTEXT_SIZE="${CONTEXT_SIZE:-4096}"
+NUM_GPUS="${NUM_GPUS:-1}"
+EXTRA_RERANK_ARGS="${EXTRA_RERANK_ARGS:-}"
+LOCAL_OUT="${LOCAL_OUT:-./colab_runs}"
+
+if [[ "$RERANK_MODE" == "requests_url" && -z "$REQUESTS_URL" ]]; then
+  echo "error: RERANK_MODE=requests_url requires REQUESTS_URL=<http url to candidates jsonl>" >&2
+  exit 1
+fi
+
+# --- Build the remote CONFIG as JSON ----------------------------------------
+export RL_REPO_URL="$REPO_URL" RL_REF="$REF" RL_WORKDIR="$WORKDIR" \
+  RL_MODEL_PATH="$MODEL_PATH" RL_RERANK_MODE="$RERANK_MODE" \
+  RL_DATASET="$DATASET" RL_RETRIEVAL_METHOD="$RETRIEVAL_METHOD" \
+  RL_REQUESTS_URL="$REQUESTS_URL" RL_TOP_K="$TOP_K" \
+  RL_CONTEXT_SIZE="$CONTEXT_SIZE" RL_NUM_GPUS="$NUM_GPUS" \
+  RL_EXTRA_RERANK_ARGS="$EXTRA_RERANK_ARGS"
+
+CONFIG_JSON="$(python3 - <<'PY'
+import json, os, shlex
+cfg = {
+    "mode": "rerank",
+    "repo_url": os.environ["RL_REPO_URL"],
+    "ref": os.environ["RL_REF"],
+    "workdir": os.environ["RL_WORKDIR"],
+    "model_path": os.environ["RL_MODEL_PATH"],
+    "rerank_mode": os.environ["RL_RERANK_MODE"],
+    "dataset": os.environ["RL_DATASET"],
+    "retrieval_method": os.environ["RL_RETRIEVAL_METHOD"],
+    "requests_url": os.environ["RL_REQUESTS_URL"],
+    "top_k": int(os.environ["RL_TOP_K"]),
+    "context_size": int(os.environ["RL_CONTEXT_SIZE"]),
+    "num_gpus": int(os.environ["RL_NUM_GPUS"]),
+    "install_pyserini": True,
+    "extra_rerank_args": shlex.split(os.environ["RL_EXTRA_RERANK_ARGS"]),
+}
+print(json.dumps(cfg))
+PY
+)"
+
+REMOTE_ARTIFACT="${WORKDIR}/colab_rerank_out.tar.gz"
+
+echo "==> rank_llm Colab reranking recipe"
+echo "    session=$SESSION GPU=$GPU model=$MODEL_PATH mode=$RERANK_MODE"
+if [[ "$RERANK_MODE" == "dataset" ]]; then
+  echo "    dataset=$DATASET retrieval=$RETRIEVAL_METHOD top_k=$TOP_K"
+else
+  echo "    requests_url=$REQUESTS_URL"
+fi
+echo "    remote artifact=$REMOTE_ARTIFACT"
+
+require_colab
+TMP_BOOTSTRAP="$(build_bootstrap "$CONFIG_JSON")"
+SESSION_CREATED=0
+cleanup() {
+  rm -f "$TMP_BOOTSTRAP"
+  if [[ "$SESSION_CREATED" == "1" ]]; then
+    stop_session "$SESSION"
+  fi
+}
+trap cleanup EXIT
+
+provision_gpu "$GPU" "$SESSION"
+SESSION_CREATED=1
+warmup_kernel "$SESSION"
+exec_bootstrap "$TMP_BOOTSTRAP" "$SESSION" "$EXEC_TIMEOUT"
+download_artifact "$REMOTE_ARTIFACT" "$LOCAL_OUT" "$SESSION"

--- a/docs/colab.md
+++ b/docs/colab.md
@@ -1,0 +1,195 @@
+# Running rank_llm on Google Colab GPUs (Colab CLI recipes)
+
+The [Google Colab CLI](https://github.com/googlecolab/google-colab-cli) lets you
+provision remote Colab GPU/TPU runtimes from your terminal (`colab new --gpu A100
+-s NAME`), run code on them (`colab exec -f FILE -s NAME`), and pull artifacts
+back (`colab download REMOTE LOCAL -s NAME`). It also ships an agent skill
+(`COLAB_SKILL.md`) so assistants like Claude Code can drive it.
+
+rank_llm's 7B reranker inference needs a GPU that many users don't have locally.
+This recipe wraps the Colab CLI so you can rerank remotely without changing how
+rank_llm works:
+
+- `colab/rerank_on_colab.sh` — listwise reranking with `rank-llm rerank`.
+
+The script provisions a runtime, clones rank_llm onto it, installs the right
+extras, runs the job, tars the output, and downloads it as a single `.tar.gz`.
+
+## Prerequisites
+
+- **Colab CLI installed** (Linux/macOS only — Windows is not supported):
+  ```bash
+  uv tool install git+https://github.com/googlecolab/google-colab-cli
+  ```
+  Authenticate once with your Google account per the CLI's instructions.
+- A clone of this repo (the scripts live in `colab/`).
+- `python3` available locally (used only to build the remote config JSON).
+
+## How it works
+
+Each recipe runs four Colab CLI steps against one named session: `colab new
+--gpu …` to provision, `colab exec -f …` to run, `colab download …` to fetch the
+artifact, and `colab stop` to release the runtime (skipped with `KEEP_SESSION=1`).
+
+`colab exec` transmits a **single** file to the runtime and provides no way to
+pass arguments. So each recipe builds a temporary bootstrap file — an injected
+`CONFIG = {...}` line prepended to `colab/_remote_bootstrap.py` — and sends that.
+On the runtime, `_remote_bootstrap.py` clones rank_llm, `pip install`s the right
+extras, runs the requested command, and prints `ARTIFACT_PATH=<remote .tar.gz>`.
+
+`colab exec` defaults to a 30s timeout, so the recipe passes a large
+`EXEC_TIMEOUT` (1h for reranking). Raise it for big jobs.
+
+## Dry run (verify without spending GPU time)
+
+Every recipe honors `DRY_RUN=1`, which prints the exact `colab` commands that
+would run instead of executing them — useful for inspecting parameters before
+provisioning a paid runtime:
+
+```bash
+DRY_RUN=1 bash colab/rerank_on_colab.sh
+```
+
+## Reranking recipe
+
+Two modes:
+
+```bash
+# (1) dataset mode (default): end-to-end on a built-in benchmark using a
+# Pyserini prebuilt index. Self-contained — installs JDK 21 + pyserini remotely.
+bash colab/rerank_on_colab.sh                       # dl19 + SPLADE++ + RankZephyr
+
+# (2) requests_url mode: rerank-only over a candidates JSONL you host somewhere
+# downloadable (HF/GCS/any http). No retrieval is run.
+RERANK_MODE=requests_url \
+  REQUESTS_URL=https://example.com/candidates.jsonl \
+  bash colab/rerank_on_colab.sh
+```
+
+Results download to `./colab_runs/colab_rerank_out.tar.gz` (contains
+`results.jsonl` and `results.trec`). In **dataset mode** rank_llm already
+evaluates against the benchmark's qrels and prints **nDCG@1/5/10** during the
+run, so the metric appears in the `colab exec` output — no extra step needed.
+
+### GPU availability and sizing
+
+Which accelerators you can provision depends on your **Colab subscription** — a
+free account is typically limited to **T4** (or CPU); `L4`/`A100`/`H100` need
+Colab Pro/Pro+. If `colab new` reports *"Backend rejected accelerator"*, you lack
+quota for that tier; pick one your plan allows.
+
+The default `castorini/rank_zephyr_7b_v1_full` is a **7B listwise** reranker
+served with vLLM (fixed `gpu_memory_utilization=0.90`), so it needs roughly
+**≥24 GB** — an L4, A100, or H100. **A 16 GB T4 cannot load it** (no room left
+for the KV cache).
+
+For a **free-tier (T4) demo**, swap in a small pointwise reranker — these run via
+`transformers`, not vLLM, and fit a T4 (or even CPU):
+
+```bash
+GPU=T4 MODEL_PATH=castorini/monot5-base-msmarco-10k RETRIEVAL_METHOD=bm25 \
+  bash colab/rerank_on_colab.sh
+# also small: MODEL_PATH=castorini/monoelectra-base
+```
+
+`RETRIEVAL_METHOD=bm25` (pure Lucene, no ONNX) is the most reliable retriever for
+a quick demo. The default `SPLADE++_EnsembleDistil_ONNX` works too — the recipe
+auto-installs `onnxruntime` — but it pulls a larger learned-sparse index.
+
+| GPU         | 7B listwise (RankZephyr) | small pointwise (monoT5-base) |
+| ----------- | ------------------------ | ----------------------------- |
+| T4 (16 GB)  | ❌ OOM                   | ✅                            |
+| L4 (24 GB)  | ✅                       | ✅                            |
+| A100/H100   | ✅ recommended           | ✅                            |
+
+### Key reranking env vars
+
+| Var | Default | Notes |
+| --- | --- | --- |
+| `GPU` | `A100` | |
+| `MODEL_PATH` | `castorini/rank_zephyr_7b_v1_full` | reranker model |
+| `RERANK_MODE` | `dataset` | `dataset` / `requests_url` |
+| `DATASET` | `dl19` | dataset-mode benchmark |
+| `RETRIEVAL_METHOD` | `SPLADE++_EnsembleDistil_ONNX` | dataset-mode retrieval |
+| `REQUESTS_URL` | (empty) | required for `requests_url` mode |
+| `TOP_K` | `100` | candidates per query |
+| `CONTEXT_SIZE` | `4096` | |
+| `NUM_GPUS` | `1` | |
+| `EXTRA_RERANK_ARGS` | (empty) | extra `rank-llm rerank` flags |
+| `SESSION` | `rankllm-rerank` | Colab session name |
+| `EXEC_TIMEOUT` | `3600` | exec timeout in seconds (raise for long runs) |
+| `KEEP_SESSION` | `0` | `1` keeps the runtime alive after the run |
+
+## Using your own local candidates file
+
+The `requests_url` mode fetches candidates over http from inside the runtime,
+which is the simplest path. If your candidates JSONL is only on your laptop, the
+CLI also has `colab upload LOCAL REMOTE -s NAME`, so you can push it onto a kept
+session and point the recipe at it:
+
+```bash
+KEEP_SESSION=1 RERANK_MODE=requests_url REQUESTS_URL=file:///content/cands.jsonl \
+  bash colab/rerank_on_colab.sh   # (then colab upload ... before exec, advanced)
+```
+
+For a smooth one-command demo, hosting the JSONL at a URL and using
+`RERANK_MODE=requests_url` is recommended.
+
+## Troubleshooting
+
+- **`Backend rejected accelerator 'X'`** — your Colab plan lacks quota for that
+  tier. Free accounts are typically T4-only; use `GPU=T4` (and a small pointwise
+  model, see above) or upgrade to Colab Pro for `L4`/`A100`/`H100`.
+- **`RuntimeError: Connection was lost.`** — the kernel websocket dropped (common
+  right after a session becomes READY, or on long-held connections). The recipes
+  warm up the kernel first and **retry `colab exec` automatically**
+  (`EXEC_RETRIES`, default 3; `EXEC_RETRY_WAIT`, default 15s). If it still fails,
+  re-run the recipe (the bootstrap is idempotent — the clone and installs are
+  reused), bump `EXEC_RETRIES`, or run `colab update` to get the latest CLI.
+- **`openai.OpenAIError: Missing credentials` during a pyserini run** — pyserini
+  1.2.0 eagerly constructs an `openai.OpenAI()` client at import time, which
+  `openai>=2` rejects when no key is set (even for bm25, which never uses it).
+  The recipe sets a placeholder `OPENAI_API_KEY` for the reranking subprocess so
+  the import succeeds; the client is never actually called.
+- **Job outlives `EXEC_TIMEOUT`** — raise it (e.g. `EXEC_TIMEOUT=7200`).
+- **Inspect a stuck run** — pass `KEEP_SESSION=1`, then attach with
+  `colab exec -s <session>` / `colab sessions`, and `colab stop -s <session>`
+  when done.
+
+## Using with an agent
+
+The Colab CLI's bundled `COLAB_SKILL.md` teaches an agent how to drive the CLI.
+With that skill loaded, you can ask an assistant to run these recipes directly,
+e.g. *"rerank dl19 with RankZephyr on an A100"* maps to
+`GPU=A100 bash colab/rerank_on_colab.sh`.
+
+## Troubleshooting
+
+The remote bootstrap (`colab/_remote_bootstrap.py`) applies the fixes below
+automatically; they are documented here in case you run the steps by hand.
+
+- **`ImportError: libcudart.so.13`** — Colab GPU images ship CUDA toolkit 12.8,
+  but recent vLLM wheels are built for CUDA 13. Install a CUDA 12.8-matched
+  pair: `pip install --force-reinstall "vllm==0.11.0" "torch==2.8.0"
+  --extra-index-url https://download.pytorch.org/whl/cu128`.
+- **`TokenizersBackend has no attribute all_special_tokens_extended`** — newer
+  `transformers` releases break vLLM 0.11.0's tokenizer backend. Pin
+  `transformers==4.55.4`.
+- **`UnsupportedClassVersionError ... class file version 65.0`** — Anserini
+  (pyserini retrieval) needs JDK 21. Install `openjdk-21-jdk-headless` and set
+  `JAVA_HOME` to it.
+- **`java.io.IOException: Error downloading topics from .../qrels.dl20-passage.txt`**
+  — pyserini's evaluator fetches qrels from a hardcoded anserini-tools URL that
+  now 404s. Pre-seed the file from NIST into
+  `~/.cache/pyserini/topics-and-qrels/qrels.<dataset>-passage.txt`
+  (e.g. `https://trec.nist.gov/data/deep/2020qrels-pass.txt` for dl20).
+
+## Reproduction results
+
+Reproduced on a Colab Pro **A100 (40 GB)**, DL20, top-100 candidates from
+`SPLADE++_EnsembleDistil_ONNX`, `context_size=4096`, `--variable-passages`:
+
+| Model | Extra flags | nDCG@10 |
+| --- | --- | --- |
+| `castorini/rank_zephyr_7b_v1_full` | (none) | 0.8195 |
+| `castorini/first_mistral` | `--use-logits --use-alpha` | 0.7859 |


### PR DESCRIPTION
## Reference Issue

ref: N/A (requested by Prof. Lin in #jarminions: "pull what you need from #407/#408/#409 to make things work". Bases on #409, which Xianda confirmed is the canonical branch of that stack.)

## Summary

Salvages the Colab CLI reranking recipe from the closed #407/#408/#409 stack and gets it running on a current Colab image. Adds `colab/rerank_on_colab.sh` (+ `_colab_common.sh`, `_remote_bootstrap.py`, `README.md`) which provisions a Colab GPU, clones rank_llm, installs the vLLM extras, runs `rank-llm rerank`, and downloads the results. `docs/colab.md` documents usage, GPU sizing, a troubleshooting section, and reproduction results.

## Why

The rz/first onboarding step needs a GPU most students don't have, and no merged recipe existed to run it on Colab (#408/#409 were closed unmerged; #414 covers only the monoT5/free-tier path). A fresh install off `main` also fails on the current Colab image due to several version issues, so the recipe wasn't usable as-is. This PR fixes those and reproduces both listwise models end to end.

## Validation

Reproduced on a Colab Pro A100 (40 GB), DL20, SPLADE++_EnsembleDistil_ONNX top-100, context_size=4096, --variable-passages:

- `castorini/rank_zephyr_7b_v1_full` → nDCG@10 = 0.8195
- `castorini/first_mistral` (`--use-logits --use-alpha`) → nDCG@10 = 0.7859

Fixes baked into `_remote_bootstrap.py` (each documented in docs/colab.md troubleshooting):
- Pin `vllm==0.11.0` + `torch==2.8.0` on the cu128 index (Colab ships CUDA 12.8; default vllm needs CUDA 13 → `libcudart.so.13` crash).
- Pin `transformers==4.55.4` (newer breaks vLLM's TokenizersBackend).
- Ensure JDK 21 for Anserini retrieval.
- Pre-seed DL qrels from NIST (pyserini's evaluator fetches a dead anserini-tools URL).

## Follow-ups

- Complements #416 (interweaving install-colab-cli.md into the RZ/FM onboarding docs); this PR is the runnable recipe, not the doc-interweaving.
- `train_on_colab.sh` from the original stack is intentionally excluded; this PR is reranking-only.

## Checklist Items

- [x] Have you followed the contributing guidelines?
- [x] Have you verified that there are no existing Pull Requests for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

- [x] Bugfix
- [x] Feature
- [x] Documentation content changes
- [x] Reproduction logs
- [ ] Other...