### PR TITLE
Interweave Colab GPU steps into RZ and FirstMistral onboarding lessons

### DIFF
--- a/docs/onboarding-first.md
+++ b/docs/onboarding-first.md
@@ -41,6 +41,10 @@ Similar to RankZephyr, we will run an end-to-end multi-stage retrieval with Firs
 
 Assuming that necessary rank_llm installation steps to run RankZephyr have been performed, one can use the following command to run FirstMistral:
 
+If you are running on Colab, follow the same setup steps from the [RankZephyr lesson](./onboarding-rz.md#running-rankzephyr-on-a-colab-gpu) (Colab CLI, A100, the vLLM/CUDA 12.8 pins, and JDK 21). The environment is identical; only the run command below changes.
+
+
+
 TODO(#416): Here and everywhere else we should switch to new clis instead of running the old `run_rank_llm.py`
 
 ```bash

--- a/docs/onboarding-rz.md
+++ b/docs/onboarding-rz.md
@@ -115,7 +115,7 @@ If you don't have a local GPU, run this step on a Colab Pro **A100** runtime, dr
 First, install the Colab CLI (Linux/macOS only). The first command that contacts Colab walks you through a one-time Google sign-in:
 
 ```bash
-uv tool install google-colab-cli
+uv tool install google-colab-cli --with "jupyter-kernel-client<1.0.0"
 ```
 
 Then provision an A100 and open a shell on it:

--- a/docs/onboarding-rz.md
+++ b/docs/onboarding-rz.md
@@ -108,6 +108,50 @@ This investment not only enables you to complete the onboarding but also positio
 
 Please refer to the [instructions here](https://github.com/castorini/rank_llm?tab=readme-ov-file#-instructions) to install rank_llm.
 
+#### Running RankZephyr on a Colab GPU
+
+If you don't have a local GPU, run this step on a Colab Pro **A100** runtime, driven from your own terminal with the [Colab CLI](https://github.com/googlecolab/google-colab-cli). Work through the steps in order.
+
+First, install the Colab CLI (Linux/macOS only). The first command that contacts Colab walks you through a one-time Google sign-in:
+
+```bash
+uv tool install google-colab-cli
+```
+
+Then provision an A100 and open a shell on it:
+
+```bash
+colab new -s rankllm --gpu A100
+colab console -s rankllm
+```
+
+Inside that shell, clone rank_llm and install it with the vLLM and Pyserini extras:
+
+```bash
+git clone https://github.com/castorini/rank_llm.git && cd rank_llm
+pip install -e '.[vllm,pyserini]' onnxruntime
+```
+
+Next, pin a CUDA 12.8-matched vLLM. The current Colab image ships CUDA 12.8, but a default vLLM is built for CUDA 13 and crashes on import with `libcudart.so.13`. Pinning vllm 0.11.0 + torch 2.8.0 from the cu128 index fixes it, and `transformers` must stay on the 4.55.x line that this vLLM targets:
+
+```bash
+pip install --force-reinstall "vllm==0.11.0" "torch==2.8.0" --extra-index-url https://download.pytorch.org/whl/cu128
+pip install "transformers==4.55.4"
+```
+
+Install JDK 21, which the Anserini/Pyserini first-stage retrieval needs:
+
+```bash
+apt-get install -y openjdk-21-jdk-headless
+export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
+```
+
+Now run the same command shown below. When it finishes, stop the runtime so you stop spending compute units:
+
+```bash
+colab stop -s rankllm
+```
+
 #### Running the RankZephyr Model
 
 We can run the RankZephyr model with the command:


### PR DESCRIPTION
## Reference Issue

ref: N/A (requested by Prof. Lin in #jarminions — fold the Colab run steps directly into the onboarding lessons so they read as part of the "do this, then this" sequence rather than a standalone doc.)

## Summary

Weaves the Colab GPU run instructions into the existing onboarding lessons:
- `onboarding-rz.md`: adds a "Running RankZephyr on a Colab GPU" section right before the run command — step-by-step Colab CLI setup (provision A100, install extras, pin CUDA 12.8-matched vLLM/torch + transformers, install JDK 21, run, stop the runtime).
- `onboarding-first.md`: points back to those same setup steps (the environment is identical; only the run command differs).

## Why

The RZ/FIRST lessons already mention needing a GPU and recommend Colab Pro, but never show how to actually run on Colab. A fresh setup on the current Colab image also hits several version issues (CUDA 12.8 vs 13 vLLM mismatch, transformers/tokenizer break, JDK 21). This folds the working, tested steps into the lesson flow so a student without a local GPU can follow straight through.

## Validation

The steps are the exact sequence used to reproduce both models on a Colab Pro A100 (40 GB), DL20, SPLADE++_EnsembleDistil_ONNX top-100:
- RankZephyr → nDCG@10 = 0.8195
- FirstMistral (`--use-logits --use-alpha`) → nDCG@10 = 0.7859

## Follow-ups

- Complements the rerank recipe scripts in #418; this PR is the lesson-integrated version of the same steps.

## Checklist Items

- [x] Have you followed the contributing guidelines?
- [x] Have you verified that there are no existing Pull Requests for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

- [x] Documentation content changes
- [ ] Bugfix
- [ ] Feature
- [ ] Reproduction logs
- [ ] Other...