### PR TITLE
Fix tuple bug in HF cached-results parsing in retriever

### DIFF
--- a/src/rank_llm/retrieve/retriever.py
+++ b/src/rank_llm/retrieve/retriever.py
@@ -206,7 +206,7 @@ class Retriever:
                 with open(cached_file) as f:
                     results = [
                         from_dict(data_class=Request, data=json.loads(line))
-                        for line in enumerate(f)
+                        for line in f
                     ]
                     for result in results:
                         result.candidates = result.candidates[:k]


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

ref: N/A

## Summary

- Fix a typo in `Retriever.retrieve()` that broke loading cached retrieval results from HF: `for line in enumerate(f)` → `for line in f`.

## Why

Because of the typo, parsing the downloaded cache always failed, so every fresh install silently fell back to full Pyserini retrieval — including a ~2 GB index download it shouldn't need. Found while verifying the new Colab onboarding guides on a clean VM.

## Validation

To validate the fix end-to-end, I tested the exact scenario the bug affects: a brand-new environment with no local caches, using a fresh Colab T4 VM. On current main, running dataset retrieval (DL20, BM25) downloads the cached results from HF but fails to parse them with the tuple error, then falls back to full Pyserini retrieval and its ~2 GB index download. On this branch, the same retrieval call on the same VM image loads the cached results directly in a few seconds — all 54 DL20 queries with 100 candidates each — and the Pyserini fallback never triggers. So the observed behavior changes from "cache always rejected" to "cache used as intended," with only this one-line change between the two runs.

## Follow-ups

- N/A

## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
