### PR TITLE
Pre-seed qrels in onboarding to fix Anserini dead download URL

### DIFF
--- a/docs/onboarding-first.md
+++ b/docs/onboarding-first.md
@@ -47,6 +47,8 @@ If you are running on Colab, follow the same setup steps from the [RankZephyr le
 
 TODO(#416): Here and everywhere else we should switch to new clis instead of running the old `run_rank_llm.py`
 
+> **Before running:** pre-seed the qrels as shown in the [RankZephyr lesson](./onboarding-rz.md) so evaluation doesn't hit Anserini's dead qrels download URL.
+
 ```bash
 python src/rank_llm/scripts/run_rank_llm.py \
   --model_path=castorini/first_mistral \

--- a/docs/onboarding-rz.md
+++ b/docs/onboarding-rz.md
@@ -156,6 +156,14 @@ colab stop -s rankllm
 
 We can run the RankZephyr model with the command:
 
+> **Before running:** the evaluation step downloads relevance judgments (qrels) that Anserini currently fetches from a hardcoded URL that no longer resolves (the qrels were moved to a `qrels/` folder upstream). Pre-seed the qrels into Pyserini's cache first so evaluation doesn't fail:
+>
+> ```bash
+> mkdir -p ~/.cache/pyserini/topics-and-qrels
+> curl -sSL -o ~/.cache/pyserini/topics-and-qrels/qrels.dl20-passage.txt \
+>   https://raw.githubusercontent.com/castorini/anserini-tools/master/qrels/qrels.dl20-passage.txt
+> ```
+
 ```bash
 python src/rank_llm/scripts/run_rank_llm.py  \
   --model_path=castorini/rank_zephyr_7b_v1_full \


### PR DESCRIPTION
## Reference Issue

ref: N/A (qrels 404 hit at the eval step in the onboarding path)

## Summary

The onboarding eval step fails for everyone on a fresh cache. Anserini's `RelevanceJudgments` downloads qrels from a hardcoded `anserini-tools/master/topics-and-qrels/` URL that no longer resolves — the qrels were moved to a `qrels/` folder upstream. This adds a short "before running" step in onboarding-rz.md and onboarding-first.md that pre-seeds the qrels into Pyserini's cache from the correct current URL, so evaluation completes.

## Why

Both RZ and FirstMistral lessons run eval automatically at the end, and it currently 404s at that step (`java.io.IOException: Error downloading topics from .../qrels.dl20-passage.txt`), so a student following the path can't get their nDCG number.

## Validation

Confirmed the old URL 404s and the new `anserini-tools/master/qrels/qrels.dl20-passage.txt` returns 200. With the qrels pre-seeded, eval runs and reproduces the target (nDCG@10 = 0.8195 for RankZephyr, 0.7859 for FirstMistral on DL20).

## Follow-ups

- This is a pragmatic fix on the rank_llm side. The root cause is the hardcoded, unpinned URL in Anserini's `RelevanceJudgments`; a more permanent fix would live upstream in Anserini (update or pin that URL).

## Checklist Items

- [x] Have you followed the contributing guidelines?
- [x] Have you verified that there are no existing Pull Requests for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

- [x] Bugfix
- [x] Documentation content changes
- [ ] Feature
- [ ] Reproduction logs
- [ ] Other...