### PR TITLE
Pre-seed qrels in colab_setup.py to fix Anserini dead download URL

### DIFF
--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -117,8 +117,10 @@ colab new -s rankllm --gpu T4
 ### Set up the environment on the VM
 
 Environment setup is boilerplate, so it's prepackaged.
-[`scripts/colab_setup.py`](../scripts/colab_setup.py) installs JDK 21 (Pyserini sits on Anserini, which is Java), clones rank_llm, and pip-installs it with the `pyserini` extra.
-Fetch it and send it to the session with an explicit timeout — installation takes a few minutes:
+[`scripts/colab_setup.py`](../scripts/colab_setup.py) installs JDK 21 (Pyserini sits on Anserini, which is Java), clones rank_llm, pip-installs it with the `pyserini` extra, and pre-seeds the DL20 relevance judgments (qrels) that the eval step below needs.
+That last part works around a real bug: Anserini's own qrels download is a hardcoded URL that no longer resolves (the file moved to a different path upstream), so without this the pipeline gets all the way through retrieval and reranking and then fails at the very last step, evaluation.
+The script fetches the file itself and drops it where Anserini's evaluator expects to find it already cached, so it never has to make that broken request.
+Fetch the script and send it to the session with an explicit timeout — installation takes a few minutes:
 
 ```bash
 curl -fsSO https://raw.githubusercontent.com/castorini/rank_llm/main/scripts/colab_setup.py
@@ -126,7 +128,7 @@ colab exec -s rankllm -f colab_setup.py --timeout 3600
 ```
 
 Do skim [the file](../scripts/colab_setup.py) — it's ~40 lines.
-Beyond the three setup commands, the one thing it has to work around is that the Colab kernel only forwards *Python-level* stdout: the OS-level output of child processes (`apt`, `git`, `pip`) is invisible unless the script captures and re-prints it, which is what its small `sh()` helper does.
+Beyond the four setup commands, the one thing it has to work around is that the Colab kernel only forwards *Python-level* stdout: the OS-level output of child processes (`apt`, `git`, `pip`, `curl`) is invisible unless the script captures and re-prints it, which is what its small `sh()` helper does.
 Without that, a failing install would die silently and you'd have nothing to debug with.
 
 Wait for the final `setup ok`.

--- a/scripts/colab_setup.py
+++ b/scripts/colab_setup.py
@@ -5,7 +5,9 @@ Sent to a Colab runtime with:
     colab exec -s rankllm -f scripts/colab_setup.py --timeout 3600
 
 Installs JDK 21 (needed by Pyserini/Anserini for first-stage retrieval and
-trec_eval), clones rank_llm, and installs it with the pyserini extra.
+trec_eval), clones rank_llm, installs it with the pyserini extra, and
+pre-seeds the DL20 qrels the eval step needs (Anserini's own qrels download
+currently 404s -- see the pre-seed step below for why).
 """
 
 import subprocess
@@ -38,5 +40,17 @@ sh(
 )
 
 sh(f"{sys.executable} -m pip install -q -e '/content/rank_llm[pyserini]'")
+
+# Anserini's own qrels download (io.anserini.eval.RelevanceJudgments) hits a
+# hardcoded anserini-tools URL that no longer resolves -- the file moved to
+# a different path upstream. Pre-seed it into Pyserini's cache here so the
+# eval step at the end of the pipeline finds it already there instead of
+# trying (and failing) to download it. See rank_llm#422 for the same fix
+# applied to the RankZephyr/FirstMistral onboarding docs.
+sh(
+    "mkdir -p ~/.cache/pyserini/topics-and-qrels && "
+    "curl -sSL -o ~/.cache/pyserini/topics-and-qrels/qrels.dl20-passage.txt "
+    "https://raw.githubusercontent.com/castorini/anserini-tools/master/qrels/qrels.dl20-passage.txt"
+)
 
 print("\nsetup ok")

--- a/scripts/colab_setup.py
+++ b/scripts/colab_setup.py
@@ -49,8 +49,10 @@ sh(f"{sys.executable} -m pip install -q -e '/content/rank_llm[pyserini]'")
 # applied to the RankZephyr/FirstMistral onboarding docs.
 sh(
     "mkdir -p ~/.cache/pyserini/topics-and-qrels && "
-    "curl -sSL -o ~/.cache/pyserini/topics-and-qrels/qrels.dl20-passage.txt "
-    "https://raw.githubusercontent.com/castorini/anserini-tools/master/qrels/qrels.dl20-passage.txt"
+    "curl -fsSL -o ~/.cache/pyserini/topics-and-qrels/qrels.dl20-passage.txt.tmp "
+    "https://raw.githubusercontent.com/castorini/anserini-tools/master/qrels/qrels.dl20-passage.txt && "
+    "mv ~/.cache/pyserini/topics-and-qrels/qrels.dl20-passage.txt.tmp "
+    "~/.cache/pyserini/topics-and-qrels/qrels.dl20-passage.txt"
 )
 
 print("\nsetup ok")


### PR DESCRIPTION
## Reference Issue

ref: N/A (same underlying bug as #422, but in a doc/script #422 didn't touch)

## Summary

- `docs/install-colab-cli.md`'s BM25+monoT5 pipeline hits the same dead Anserini qrels URL that #422 fixed for the RankZephyr/FirstMistral lessons -- `io.anserini.eval.RelevanceJudgments` still tries to download qrels from a hardcoded `anserini-tools/master/topics-and-qrels/` URL that 404s.
- #422 fixed this for `onboarding-rz.md` and `onboarding-first.md` with a manual "before running" doc step. This doc's setup already runs through `scripts/colab_setup.py`, so instead of adding a third copy-pasted manual step, this bakes the same pre-seed into that script as a fourth automatic setup step.
- Updated `install-colab-cli.md`'s description of what the script does, and explained why the qrels step exists, matching the guide's existing "explain what's happening" style.

## Why

Every new student following the onboarding path in order hits `install-colab-cli.md` first, before either lesson #422 fixed. Right now that means the very first pipeline they run crashes at the last step with an unexplained `java.io.IOException` and no indication of what went wrong. Confirmed by reproducing it directly: ran the documented BM25+monoT5 command on a fresh Colab session and hit the same `RelevanceJudgments.downloadQrels` failure #422 describes.

## Validation

```bash
python3 -m ruff check scripts/colab_setup.py
python3 -m ruff format --check scripts/colab_setup.py
python3 -m py_compile scripts/colab_setup.py
```
All clean. No existing unit tests cover `scripts/colab_setup.py` (Colab-runtime-only, not imported under `src/`), so no test changes -- correctness check is the same one #422 used: the old `anserini-tools/master/topics-and-qrels/` URL 404s, `anserini-tools/master/qrels/` returns 200.

## Follow-ups

- Same root cause as #422's follow-up: the real fix belongs upstream in Anserini (already merged there, castorini/anserini#3319), and this workaround becomes unnecessary once a pyserini release ships the updated Anserini jar and rank_llm's pin moves to it (tracked in #405).

## Checklist Items

- [x] Have you followed the contributing guidelines?
- [x] Have you verified that there are no existing Pull Requests for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Reproduction logs
- [ ] Other...
    - Description: