### PR TITLE
Fix colab stop ordering and add connection-drop guidance in RankZephy…

### DIFF
--- a/docs/onboarding-rz.md
+++ b/docs/onboarding-rz.md
@@ -125,6 +125,12 @@ colab new -s rankllm --gpu A100
 colab console -s rankllm
 ```
 
+This session stays open through several long steps — installs, then loading and compiling a 7B model — so it's worth knowing what a dropped connection means before you hit one:
+
+- `Connection closed` on its own just means the client disconnected; the VM and your work are still there. Re-run `colab console -s rankllm` to reattach — it's tmux-backed.
+- `Session 'rankllm' appears to be lost (404/401)` means the VM itself is gone. There's nothing to reattach to; reprovision with `colab new` and start over.
+- To cut down on drops, keep your laptop from sleeping for the duration — on macOS: `caffeinate -i colab console -s rankllm` (this only holds sleep off while `colab console` is running; it exits, and normal sleep resumes, the moment that does — whether that's `exit`, Ctrl-C, or a dropped connection — so there's nothing to remember to turn off).
+
 Inside that shell, clone rank_llm and install it with the vLLM and Pyserini extras:
 
 ```bash
@@ -146,11 +152,7 @@ apt-get install -y openjdk-21-jdk-headless
 export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 ```
 
-Now run the same command shown below. When it finishes, stop the runtime so you stop spending compute units:
-
-```bash
-colab stop -s rankllm
-```
+Setup is done. Stay in this console session for the actual run below — don't stop the runtime yet.
 
 #### Running the RankZephyr Model
 
@@ -185,6 +187,18 @@ Note that the result you get may vary slightly with the number above.
 _Where is the first-stage retrieval?_
 It is hidden in the `--retrieval_method=SPLADE++_EnsembleDistil_ONNX` flag.
 We are using the [SPLADE](https://www.pinecone.io/learn/splade/) model as our sparse first-stage retriever, retrieving the top 100 candidates, followed by the RankZephyr model to rerank these 100 candidates.
+
+Before leaving the VM, exit the console:
+
+```bash
+exit
+```
+
+Back on your machine, stop the runtime so you stop spending compute units:
+
+```bash
+colab stop -s rankllm
+```
 
 That is all for this guide!
 A reminder that this is just a gentle introduction, and the field is still largely an active area of research; we welcome you to join us in exploring the exciting possibilities of reranking with LLMs!


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

ref: N/A (related to #416, the broader onboarding-docs cleanup issue, but not a direct fix for it)

## Summary

- Reorder the misplaced `colab stop -s rankllm` block in `onboarding-rz.md` so it runs after the actual RankZephyr run instead of before it
- Add a short callout distinguishing a recoverable connection drop from an actual lost Colab session, plus a `caffeinate` tip, since RankZephyr's install + model-load steps run long enough for this to matter in practice

## Why

As written, "Now run the same command shown below. When it finishes, stop the runtime so you stop spending compute units:" is immediately followed by the `colab stop -s rankllm` snippet — before the actual run command, which only appears two subsections later under "Running the RankZephyr Model." Read top to bottom, that reads as an instruction to run `colab stop` right there.

Hit this directly while working through the guide: `colab stop -s rankllm` typed inside the `colab console` session fails harmlessly (`colab` isn't installed on the VM, so it's just `command not found`), but reacting to that error by exiting and re-running the command correctly — on the local machine — stops the runtime before RankZephyr ever executes, wiping the environment setup that had just finished.

Separately, the RankZephyr setup (vllm/torch/transformers install) plus loading and compiling the 7B model runs long enough that Colab connection drops became a real, repeated issue while validating this guide, and the doc had no guidance on what a drop means or what to do about it.

Not part of a stack — standalone doc fix.

## Validation

```bash
colab new -s rankllm --gpu A100
caffeinate -i colab console -s rankllm
# inside the console, following the corrected doc: git clone, pip installs,
# JDK, qrels pre-seed, then:
python src/rank_llm/scripts/run_rank_llm.py \
  --model_path=castorini/rank_zephyr_7b_v1_full \
  --top_k_candidates=100 --dataset=dl20 \
  --retrieval_method=SPLADE++_EnsembleDistil_ONNX \
  --prompt_template_path=src/rank_llm/rerank/prompt_templates/rank_zephyr_template.yaml \
  --context_size=4096 --variable_passages
# -> ndcg_cut_10 ~0.82, matching the guide's expected result
exit
colab stop -s rankllm

.venv/bin/pre-commit run --all-files
python -m unittest discover test
```

Also continued into `onboarding-first.md` afterward with no issues, confirming the fix doesn't change FirstMistral's environment assumptions.

## Follow-ups

- A similar reordering/clarity pass over the rest of the onboarding docs is probably worth doing per #416, but out of scope here

## Checklist Items

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Reproduction logs
- [ ] Other...
    - Description: