### PR TITLE
Fix vLLM context length for listwise rerankers

### DIFF
--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -185,7 +185,8 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 )
                 self._tokenizer = self._vllm_handler.get_tokenizer()
             else:
-                # Use the AutoTokenizer from the transformers library to load the tokenizer, since the initialization of the VllmHandler needs max_model_len which is calculated using the tokenizer.
+                # Preload the tokenizer before initializing the vLLM handler. The
+                # handler's tokenizer replaces it once the engine is ready.
                 if AutoTokenizer is None:
                     raise missing_extra_error(
                         "local",
@@ -194,7 +195,6 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 self._tokenizer = AutoTokenizer.from_pretrained(
                     model, trust_remote_code=True
                 )
-                max_output = self._get_max_output_tokens(self._window_size)
                 self._vllm_handler = VllmHandler(
                     model=model,
                     download_dir=os.getenv("HF_HOME"),
@@ -203,7 +203,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                     tensor_parallel_size=num_gpus,
                     gpu_memory_utilization=0.90,
                     trust_remote_code=True,
-                    max_model_len=context_size + max_output,
+                    max_model_len=context_size,
                 )
             # Now that the VllmHandler is initialized, we can get the tokenizer from it.
             self._tokenizer = self._vllm_handler.get_tokenizer()

--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -79,7 +79,8 @@ class RankListwiseOSLLM(ListwiseRankLLM):
 
          Parameters:
          - model (str): Identifier for the language model to be used for ranking tasks.
-         - context_size (int, optional): Maximum number of tokens that can be handled in a single prompt. Defaults to 4096.
+         - context_size (int, optional): Total token budget for the prompt and ranking output, excluding any optional
+         reasoning token budget. Defaults to 4096.
          - prompt_mode (PromptMode, optional): Deprecated and ignored. Prompt behavior is driven by the YAML
          template at prompt_template_path; passing prompt_mode only emits a deprecation warning.
          - num_few_shot_examples (int, optional): Number of few-shot learning examples to include in the prompt, allowing for
@@ -94,6 +95,9 @@ class RankListwiseOSLLM(ListwiseRankLLM):
          - stride (int, optional): The stride size for moving the window. Defaults to 10.
          - system_message (Optional[str], optional): Custom system message to be included in the prompt for additional
          instructions or context. Defaults to None.
+         - is_thinking (bool, optional): Whether to reserve additional output capacity for model reasoning. Defaults to False.
+         - reasoning_token_budget (int, optional): Additional output-token capacity reserved when thinking is enabled.
+         Defaults to 10000.
          - use_logits (bool, optional): Indicates whether to use logits or not. Defaults to False.
          - use_alpha (bool, optional): Indicates whether to use alphabet ordering the prompts. Defaults to False.
          - sglang_batched (bool, optional): Indicates whether batched inference using SGLang is leveraged. Defaults to False.
@@ -185,8 +189,8 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                 )
                 self._tokenizer = self._vllm_handler.get_tokenizer()
             else:
-                # Preload the tokenizer before initializing the vLLM handler. The
-                # handler's tokenizer replaces it once the engine is ready.
+                # Preload the tokenizer because the engine capacity calculation
+                # needs the ranking output-token estimate.
                 if AutoTokenizer is None:
                     raise missing_extra_error(
                         "local",
@@ -203,7 +207,7 @@ class RankListwiseOSLLM(ListwiseRankLLM):
                     tensor_parallel_size=num_gpus,
                     gpu_memory_utilization=0.90,
                     trust_remote_code=True,
-                    max_model_len=context_size,
+                    max_model_len=self._get_max_model_len(self._window_size),
                 )
             # Now that the VllmHandler is initialized, we can get the tokenizer from it.
             self._tokenizer = self._vllm_handler.get_tokenizer()
@@ -281,6 +285,12 @@ class RankListwiseOSLLM(ListwiseRankLLM):
     def _get_max_output_tokens(self, window_size: int) -> int:
         min_tok = self.num_output_tokens(window_size)
         return self._reasoning_token_budget + min_tok if self._is_thinking else min_tok
+
+    def _get_max_model_len(self, window_size: int) -> int:
+        """Return the engine capacity needed by the prompt and output budgets."""
+        ranking_output_tokens = self.num_output_tokens(window_size)
+        max_prompt_tokens = self.max_tokens() - ranking_output_tokens
+        return max_prompt_tokens + self._get_max_output_tokens(window_size)
 
     async def run_llm_async(
         self,

--- a/test/rerank/listwise/test_RankListwiseOSLLM.py
+++ b/test/rerank/listwise/test_RankListwiseOSLLM.py
@@ -195,22 +195,26 @@ class TestRankListwiseOSLLM(unittest.TestCase):
         self.assertTrue(hasattr(model_coordinator, "_vllm_handler"))
         self.assertIsNone(model_coordinator._base_url)
 
-    def test_vllm_max_model_len_matches_context_size(self):
-        for model in (
-            "castorini/rank_zephyr_7b_v1_full",
-            "castorini/rank_vicuna_7b_v1",
-        ):
-            with self.subTest(model=model):
+    def test_vllm_max_model_len_covers_prompt_and_output_budgets(self):
+        cases = (
+            ("castorini/rank_zephyr_7b_v1_full", False, 10000, 4096),
+            ("castorini/rank_vicuna_7b_v1", False, 10000, 4096),
+            ("deepseek-ai/DeepSeek-R1-0528-Qwen3-8B", True, 30000, 34096),
+        )
+        for model, is_thinking, reasoning_token_budget, expected in cases:
+            with self.subTest(model=model, is_thinking=is_thinking):
                 self.mock_vllm_handler_class.reset_mock()
                 RankListwiseOSLLM(
                     model=model,
                     context_size=4096,
                     window_size=20,
+                    is_thinking=is_thinking,
+                    reasoning_token_budget=reasoning_token_budget,
                 )
 
                 self.assertEqual(
                     self.mock_vllm_handler_class.call_args.kwargs["max_model_len"],
-                    4096,
+                    expected,
                 )
 
     def test_init_with_openai_sdk(self):

--- a/test/rerank/listwise/test_RankListwiseOSLLM.py
+++ b/test/rerank/listwise/test_RankListwiseOSLLM.py
@@ -195,6 +195,24 @@ class TestRankListwiseOSLLM(unittest.TestCase):
         self.assertTrue(hasattr(model_coordinator, "_vllm_handler"))
         self.assertIsNone(model_coordinator._base_url)
 
+    def test_vllm_max_model_len_matches_context_size(self):
+        for model in (
+            "castorini/rank_zephyr_7b_v1_full",
+            "castorini/rank_vicuna_7b_v1",
+        ):
+            with self.subTest(model=model):
+                self.mock_vllm_handler_class.reset_mock()
+                RankListwiseOSLLM(
+                    model=model,
+                    context_size=4096,
+                    window_size=20,
+                )
+
+                self.assertEqual(
+                    self.mock_vllm_handler_class.call_args.kwargs["max_model_len"],
+                    4096,
+                )
+
     def test_init_with_openai_sdk(self):
         model_coordinator = RankListwiseOSLLM(
             model="castorini/rank_zephyr_7b_v1_full",


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

Please provide the reference to issue this PR is addressing (# followed by the issue number). If there is no associated issue, write "N/A".

ref: N/A

## Summary

Fix vLLM context-window accounting for local listwise rerankers.

The engine capacity is now derived from the maximum fitted prompt and maximum generated output:

`max_model_len = max_prompt_tokens + max_output_tokens`

This results in:

Non-thinking: `max_model_len = context_size`
Thinking: `max_model_len = context_size + reasoning_token_budget`

The change also clarifies the meaning of context_size and adds regression coverage for both ordinary and thinking rerankers.

## Why

Prompt construction already reserves tokens for the final ranking:

`max_prompt_tokens = context_size - ranking_output_tokens`

Previously, vLLM was initialized using:

`context_size + max_output_tokens`

For non-thinking rerankers, this counted ranking-output capacity twice. For example, a 4096-token Vicuna configuration requested a 4186-token engine context and failed because the model supports a maximum of 4096 tokens.

Using only `context_size` fixes ordinary rerankers but does not preserve the additional output capacity required by thinking models. The new calculation handles both cases consistently:

Non-thinking:
`(context_size - ranking_tokens) + ranking_tokens = context_size`

Thinking:
```
(context_size - ranking_tokens)
+ reasoning_token_budget
+ ranking_tokens
= context_size + reasoning_token_budget
```

This is implemented in the shared local listwise vLLM path and does not depend on specific model names.

## Validation

List the exact commands you ran, for example:

```bash
uv run pre-commit run --all-files
uv run python -m unittest discover test
```

Note: mainvenv is my local env name.
```
mainvenv/bin/python -m unittest \
    test.rerank.listwise.test_RankListwiseOSLLM

mainvenv/bin/python -m unittest discover test/rerank/listwise

mainvenv/bin/ruff check \
  src/rank_llm/rerank/listwise/rank_listwise_os_llm.py \
  test/rerank/listwise/test_RankListwiseOSLLM.py

mainvenv/bin/ruff format --check \
  src/rank_llm/rerank/listwise/rank_listwise_os_llm.py \
  test/rerank/listwise/test_RankListwiseOSLLM.py
```

## Follow-ups

## Checklist Items

Before submitting your pull request, please review these items:

- [ ] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [ ] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [ ] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
