### PR TITLE
Fix for vLLM engine cleanup

### DIFF
--- a/src/rank_llm/demo/rerank_inline_hits.py
+++ b/src/rank_llm/demo/rerank_inline_hits.py
@@ -75,15 +75,19 @@ request_dict = {
 }
 request = from_dict(data_class=Request, data=request_dict)
 
-reranker = ZephyrReranker()
 kwargs = {"populate_invocations_history": True}
-rerank_results = reranker.rerank(request=request, **kwargs)
-
-# Explicitly free up before creating another reranker.
-del reranker
+reranker = ZephyrReranker()
+try:
+    rerank_results = reranker.rerank(request=request, **kwargs)
+finally:
+    # vLLM runs the engine in a subprocess; close it before loading another model.
+    reranker.close()
 
 reranker = VicunaReranker()
-rerank_results = reranker.rerank(request=request, **kwargs)
+try:
+    rerank_results = reranker.rerank(request=request, **kwargs)
+finally:
+    reranker.close()
 print(rerank_results)
 
 # write rerank results

--- a/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
+++ b/src/rank_llm/rerank/listwise/rank_listwise_os_llm.py
@@ -212,6 +212,12 @@ class RankListwiseOSLLM(ListwiseRankLLM):
             # Now that the VllmHandler is initialized, we can get the tokenizer from it.
             self._tokenizer = self._vllm_handler.get_tokenizer()
 
+    def close(self) -> None:
+        """Release resources owned by the active inference backend."""
+        close = getattr(getattr(self, "_vllm_handler", None), "close", None)
+        if close is not None:
+            close()
+
     def rerank_batch(
         self,
         requests: list[Request],

--- a/src/rank_llm/rerank/listwise/vicuna_reranker.py
+++ b/src/rank_llm/rerank/listwise/vicuna_reranker.py
@@ -150,3 +150,7 @@ class VicunaReranker:
             logging=logging,
             **kwargs,
         )
+
+    def close(self) -> None:
+        """Release resources owned by the underlying reranker."""
+        self._reranker.close()

--- a/src/rank_llm/rerank/listwise/zephyr_reranker.py
+++ b/src/rank_llm/rerank/listwise/zephyr_reranker.py
@@ -148,3 +148,7 @@ class ZephyrReranker:
             logging=logging,
             **kwargs,
         )
+
+    def close(self) -> None:
+        """Release resources owned by the underlying reranker."""
+        self._reranker.close()

--- a/src/rank_llm/rerank/vllm_handler.py
+++ b/src/rank_llm/rerank/vllm_handler.py
@@ -1,6 +1,6 @@
 import asyncio
-import atexit
 import uuid
+import weakref
 from typing import TYPE_CHECKING, Any
 
 try:
@@ -54,13 +54,32 @@ class VllmHandler:
         self._engine = vllm.AsyncLLMEngine.from_engine_args(engine_args)
         self._model = model
         self._tokenizer: PreTrainedTokenizerBase | None = None
-        atexit.register(self._shutdown)
+        self._closed = False
+        # Do not register a bound method with atexit: that keeps this handler
+        # alive and prevents `del reranker` from releasing the engine process.
+        self._finalizer = weakref.finalize(
+            self, self._shutdown_engine_safely, self._engine
+        )
 
-    def _shutdown(self) -> None:
+    @staticmethod
+    def _shutdown_engine_safely(engine: Any) -> None:
         try:
-            self._engine.shutdown()
+            engine.shutdown()
         except Exception:
             pass
+
+    def close(self) -> None:
+        """Synchronously release the vLLM engine and its GPU resources."""
+        if self._closed:
+            return
+        engine = self._engine
+        engine.shutdown()
+        self._closed = True
+        self._finalizer.detach()
+        # Drop the last handler-owned reference now, while vLLM and pyzmq
+        # module globals are still intact. Otherwise their __del__ methods run
+        # during interpreter teardown and can call globals that are already None.
+        self._engine = None
 
     def get_tokenizer(self) -> PreTrainedTokenizerBase:
         if self._tokenizer is None:

--- a/test/rerank/listwise/test_RankListwiseOSLLM.py
+++ b/test/rerank/listwise/test_RankListwiseOSLLM.py
@@ -195,6 +195,17 @@ class TestRankListwiseOSLLM(unittest.TestCase):
         self.assertTrue(hasattr(model_coordinator, "_vllm_handler"))
         self.assertIsNone(model_coordinator._base_url)
 
+    def test_close_delegates_to_vllm_handler(self):
+        model_coordinator = RankListwiseOSLLM(
+            model="castorini/rank_zephyr_7b_v1_full",
+            context_size=4096,
+            window_size=10,
+        )
+
+        model_coordinator.close()
+
+        self.mock_vllm_handler_instance.close.assert_called_once_with()
+
     def test_vllm_max_model_len_covers_prompt_and_output_budgets(self):
         cases = (
             ("castorini/rank_zephyr_7b_v1_full", False, 10000, 4096),

--- a/test/rerank/listwise/test_listwise_reranker_cleanup.py
+++ b/test/rerank/listwise/test_listwise_reranker_cleanup.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import MagicMock
+
+from rank_llm.rerank.listwise.vicuna_reranker import VicunaReranker
+from rank_llm.rerank.listwise.zephyr_reranker import ZephyrReranker
+
+
+class TestListwiseRerankerCleanup(unittest.TestCase):
+    def test_convenience_rerankers_delegate_close(self):
+        for reranker_class in (ZephyrReranker, VicunaReranker):
+            with self.subTest(reranker=reranker_class.__name__):
+                reranker = reranker_class.__new__(reranker_class)
+                reranker._reranker = MagicMock()
+
+                reranker.close()
+
+                reranker._reranker.close.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/rerank/test_VllmHandler.py
+++ b/test/rerank/test_VllmHandler.py
@@ -1,5 +1,7 @@
 import asyncio
+import gc
 import unittest
+import weakref
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from rank_llm.rerank import vllm_handler as vllm_handler_module
@@ -8,13 +10,11 @@ from rank_llm.rerank import vllm_handler as vllm_handler_module
 class TestVllmHandler(unittest.TestCase):
     def setUp(self):
         self.patcher_vllm = patch.object(vllm_handler_module, "vllm", MagicMock())
-        self.patcher_atexit = patch("atexit.register")
 
         self.mock_vllm = self.patcher_vllm.start()
         self.mock_engine_args_class = self.mock_vllm.AsyncEngineArgs
         self.mock_engine_class = self.mock_vllm.AsyncLLMEngine
         self.mock_sampling_params_class = self.mock_vllm.SamplingParams
-        self.patcher_atexit.start()
 
         self.mock_engine_instance = self.mock_engine_class.from_engine_args.return_value
         self.mock_tokenizer = MagicMock()
@@ -35,8 +35,8 @@ class TestVllmHandler(unittest.TestCase):
         )
 
     def tearDown(self):
+        self.handler.close()
         self.patcher_vllm.stop()
-        self.patcher_atexit.stop()
 
     def test_init(self):
         self.mock_engine_class.from_engine_args.assert_called_once_with(
@@ -45,6 +45,33 @@ class TestVllmHandler(unittest.TestCase):
         self.assertEqual(self.handler._engine, self.mock_engine_instance)
         self.assertEqual(self.handler._model, "test-model")
         self.assertIsNone(self.handler._tokenizer)
+
+    def test_close_is_idempotent(self):
+        self.handler.close()
+        self.handler.close()
+
+        self.mock_engine_instance.shutdown.assert_called_once_with()
+        self.assertFalse(self.handler._finalizer.alive)
+        self.assertIsNone(self.handler._engine)
+
+    def test_garbage_collection_shuts_down_engine(self):
+        engine = MagicMock()
+        self.mock_engine_class.from_engine_args.return_value = engine
+        handler = type(self.handler)(
+            model="collected-model",
+            download_dir="/tmp",
+            enforce_eager=True,
+            max_logprobs=5,
+            tensor_parallel_size=1,
+            gpu_memory_utilization=0.5,
+        )
+        handler_ref = weakref.ref(handler)
+
+        del handler
+        gc.collect()
+
+        self.assertIsNone(handler_ref())
+        engine.shutdown.assert_called_once_with()
 
     def test_get_tokenizer(self):
         tokenizer = self.handler.get_tokenizer()


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

Please provide the reference to issue this PR is addressing (# followed by the issue number). If there is no associated issue, write "N/A".

ref: N/A

Note: to prevent merge conflict issues, this PR is stacked on top of another bugfix PR, which should ideally be merged first: https://github.com/castorini/rank_llm/pull/425.

Therefore, until that PR is merged, this will include diffs of that PR as well.

## Summary
Fixes CUDA OOM errors when loading multiple local vLLM rerankers sequentially.

The previous atexit callback retained the first reranker’s engine, preventing its GPU resources from being
released before the next model initialized.

The previous atexit callback retained the first reranker’s engine, preventing its GPU resources from being released before the next model initialized.
- Use weakref.finalize as a safe fallback cleanup mechanism.
- Propagate cleanup through RankListwiseOSLLM, ZephyrReranker, and VicunaReranker.
- Update the inline reranking demo to close each model before loading the next.
- Add tests for explicit cleanup, repeated cleanup, and garbage-collection fallback.

## Why

## Validation

List the exact commands you ran, for example:
Before this PR, the following command was unsuccessful in prod:
`python src/rank_llm/demo/rerank_inline_hits.py`

Now, with this PR, it returns:
```
Template validated successfully!
Successfully created singleturn_listwise inference handler!
INFO 08-26 22:25:01 [model.py:549] Resolved architecture: MistralForCausalLM
INFO 08-26 22:25:01 [model.py:1678] Using max model len 4096
INFO 08-26 22:25:01 [scheduler.py:238] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 08-26 22:25:01 [vllm.py:790] Asynchronous scheduling is enabled.
(EngineCore pid=1992345) INFO 08-26 22:25:05 [core.py:105] Initializing a V1 LLM engine (v0.19.1) with config: model='castorini/rank_zephyr_7b_v1_full', speculative_config=None, tokenizer='castorini/rank_zephyr_7b_v1_full', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=4096, download_dir='/home/tardis/shared/raghavv', load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=castorini/rank_zephyr_7b_v1_full, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_images_per_batch': 0, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 256, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=1992345) INFO 08-26 22:25:06 [parallel_state.py:1400] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://129.97.186.23:41659 backend=nccl
(EngineCore pid=1992345) INFO 08-26 22:25:06 [parallel_state.py:1716] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore pid=1992345) INFO 08-26 22:25:08 [gpu_model_runner.py:4735] Starting to load model castorini/rank_zephyr_7b_v1_full...
(EngineCore pid=1992345) INFO 08-26 22:25:09 [cuda.py:334] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore pid=1992345) INFO 08-26 22:25:09 [flash_attn.py:596] Using FlashAttention version 2
(EngineCore pid=1992345) <frozen importlib._bootstrap_external>:1241: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore pid=1992345) <frozen importlib._bootstrap_external>:1241: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
Loading safetensors checkpoint shards:   0% Completed | 0/3 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  33% Completed | 1/3 [00:24<00:49, 24.61s/it]
Loading safetensors checkpoint shards:  67% Completed | 2/3 [00:49<00:24, 24.59s/it]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:51<00:00, 14.52s/it]
Loading safetensors checkpoint shards: 100% Completed | 3/3 [00:51<00:00, 17.24s/it]
(EngineCore pid=1992345) 
(EngineCore pid=1992345) INFO 08-26 22:26:02 [default_loader.py:384] Loading weights took 51.88 seconds
(EngineCore pid=1992345) INFO 08-26 22:26:03 [gpu_model_runner.py:4820] Model loading took 13.5 GiB memory and 54.145678 seconds
(EngineCore pid=1992345) INFO 08-26 22:26:12 [backends.py:1051] Using cache directory: /home/raghavv/.cache/vllm/torch_compile_cache/bdfc92a035/rank_0_0/backbone for vLLM's torch.compile
(EngineCore pid=1992345) INFO 08-26 22:26:12 [backends.py:1111] Dynamo bytecode transform time: 8.08 s
(EngineCore pid=1992345) INFO 08-26 22:26:16 [backends.py:285] Directly load the compiled graph(s) for compile range (1, 2048) from the cache, took 3.758 s
(EngineCore pid=1992345) INFO 08-26 22:26:16 [decorators.py:305] Directly load AOT compilation from path /home/raghavv/.cache/vllm/torch_compile_cache/torch_aot_compile/879f657b7662ebdd3d7bb71c05d9cefb48733fbe26fb027d65f8e65fb5d84500/rank_0_0/model
(EngineCore pid=1992345) INFO 08-26 22:26:16 [monitor.py:48] torch.compile took 12.36 s in total
(EngineCore pid=1992345) INFO 08-26 22:26:16 [monitor.py:76] Initial profiling/warmup run took 0.22 s
(EngineCore pid=1992345) INFO 08-26 22:26:17 [kv_cache_utils.py:829] Overriding num_gpu_blocks=0 with num_gpu_blocks_override=256
(EngineCore pid=1992345) INFO 08-26 22:26:17 [gpu_model_runner.py:5876] Profiling CUDA graph memory: PIECEWISE=35 (largest=256), FULL=19 (largest=128)
(EngineCore pid=1992345) INFO 08-26 22:26:19 [gpu_model_runner.py:5955] Estimated CUDA graph memory: 0.99 GiB total
(EngineCore pid=1992345) INFO 08-26 22:26:19 [gpu_worker.py:436] Available KV cache memory: 7.36 GiB
(EngineCore pid=1992345) INFO 08-26 22:26:19 [gpu_worker.py:470] In v0.19, CUDA graph memory profiling will be enabled by default (VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1), which more accurately accounts for CUDA graph memory during KV cache allocation. To try it now, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1 and increase --gpu-memory-utilization from 0.9000 to 0.9421 to maintain the same effective KV cache size.
(EngineCore pid=1992345) INFO 08-26 22:26:19 [kv_cache_utils.py:1319] GPU KV cache size: 60,304 tokens
(EngineCore pid=1992345) INFO 08-26 22:26:19 [kv_cache_utils.py:1324] Maximum concurrency for 4,096 tokens per request: 14.67x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████| 35/35 [00:02<00:00, 13.73it/s]
Capturing CUDA graphs (decode, FULL): 100%|█████████████████████████████████████| 19/19 [00:01<00:00, 17.13it/s]
(EngineCore pid=1992345) INFO 08-26 22:26:24 [gpu_model_runner.py:6046] Graph capturing finished in 5 secs, took 0.35 GiB
(EngineCore pid=1992345) INFO 08-26 22:26:24 [gpu_worker.py:597] CUDA graph pool memory: 0.35 GiB (actual), 0.99 GiB (estimated), difference: 0.64 GiB (185.4%).
(EngineCore pid=1992345) INFO 08-26 22:26:24 [core.py:283] init engine (profile, create kv cache, warmup model) took 20.83 seconds
Sliding windows:   0%|                                                                    | 0/1 [00:00<?, ?it/s]2026-08-26 22:26:24,963 - INFO - Async VLLM Generating!
WARNING 08-26 22:26:24 [input_processor.py:235] Passing raw prompts to InputProcessor is deprecated and will be removed in v0.18. You should instead pass the outputs of Renderer.render_cmpl() or Renderer.render_chat().
Sliding windows: 100%|████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.33it/s]
(EngineCore pid=1992345) INFO 08-26 22:26:25 [core.py:1210] Shutdown initiated (timeout=0)
(EngineCore pid=1992345) INFO 08-26 22:26:25 [core.py:1233] Shutdown complete
Template validated successfully!
Successfully created singleturn_listwise inference handler!
INFO 08-26 22:26:27 [model.py:549] Resolved architecture: LlamaForCausalLM
INFO 08-26 22:26:27 [model.py:1678] Using max model len 4096
[transformers] The following generation flags are not valid and may be ignored: ['temperature', 'top_p']. Set `TRANSFORMERS_VERBOSITY=info` for more details.
(EngineCore pid=1992630) INFO 08-26 22:26:28 [core.py:105] Initializing a V1 LLM engine (v0.19.1) with config: model='castorini/rank_vicuna_7b_v1', speculative_config=None, tokenizer='castorini/rank_vicuna_7b_v1', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.float16, max_seq_len=4096, download_dir='/home/tardis/shared/raghavv', load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=castorini/rank_vicuna_7b_v1, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'splitting_ops': ['vllm::unified_attention', 'vllm::unified_attention_with_output', 'vllm::unified_mla_attention', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_images_per_batch': 0, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 256, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': True, 'static_all_moe_layers': []}
(EngineCore pid=1992630) INFO 08-26 22:26:28 [parallel_state.py:1400] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://129.97.186.23:51875 backend=nccl
(EngineCore pid=1992630) INFO 08-26 22:26:28 [parallel_state.py:1716] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore pid=1992630) INFO 08-26 22:26:29 [gpu_model_runner.py:4735] Starting to load model castorini/rank_vicuna_7b_v1...
(EngineCore pid=1992630) INFO 08-26 22:26:31 [cuda.py:334] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore pid=1992630) INFO 08-26 22:26:31 [flash_attn.py:596] Using FlashAttention version 2
(EngineCore pid=1992630) <frozen importlib._bootstrap_external>:1241: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore pid=1992630) <frozen importlib._bootstrap_external>:1241: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
Loading pt checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
Loading pt checkpoint shards:  50% Completed | 1/2 [01:10<01:10, 70.17s/it]
Loading pt checkpoint shards: 100% Completed | 2/2 [01:38<00:00, 45.31s/it]
Loading pt checkpoint shards: 100% Completed | 2/2 [01:38<00:00, 49.04s/it]
(EngineCore pid=1992630) 
(EngineCore pid=1992630) INFO 08-26 22:28:10 [default_loader.py:384] Loading weights took 98.10 seconds
(EngineCore pid=1992630) INFO 08-26 22:28:11 [gpu_model_runner.py:4820] Model loading took 12.55 GiB memory and 100.041478 seconds
(EngineCore pid=1992630) INFO 08-26 22:28:22 [backends.py:1051] Using cache directory: /home/raghavv/.cache/vllm/torch_compile_cache/20c5ea45ac/rank_0_0/backbone for vLLM's torch.compile
(EngineCore pid=1992630) INFO 08-26 22:28:22 [backends.py:1111] Dynamo bytecode transform time: 10.87 s
(EngineCore pid=1992630) INFO 08-26 22:28:26 [backends.py:285] Directly load the compiled graph(s) for compile range (1, 2048) from the cache, took 3.957 s
(EngineCore pid=1992630) INFO 08-26 22:28:26 [decorators.py:305] Directly load AOT compilation from path /home/raghavv/.cache/vllm/torch_compile_cache/torch_aot_compile/3997ce5962ffd220aa120b64217b98adb8edad93784d3717af66ea5f8eab30e7/rank_0_0/model
(EngineCore pid=1992630) INFO 08-26 22:28:26 [monitor.py:48] torch.compile took 15.33 s in total
(EngineCore pid=1992630) INFO 08-26 22:28:27 [monitor.py:76] Initial profiling/warmup run took 0.35 s
(EngineCore pid=1992630) INFO 08-26 22:28:28 [kv_cache_utils.py:829] Overriding num_gpu_blocks=0 with num_gpu_blocks_override=256
(EngineCore pid=1992630) INFO 08-26 22:28:28 [gpu_model_runner.py:5876] Profiling CUDA graph memory: PIECEWISE=35 (largest=256), FULL=19 (largest=128)
(EngineCore pid=1992630) INFO 08-26 22:28:30 [gpu_model_runner.py:5955] Estimated CUDA graph memory: 0.32 GiB total
(EngineCore pid=1992630) INFO 08-26 22:28:30 [gpu_worker.py:436] Available KV cache memory: 8.34 GiB
(EngineCore pid=1992630) INFO 08-26 22:28:30 [gpu_worker.py:470] In v0.19, CUDA graph memory profiling will be enabled by default (VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1), which more accurately accounts for CUDA graph memory during KV cache allocation. To try it now, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1 and increase --gpu-memory-utilization from 0.9000 to 0.9138 to maintain the same effective KV cache size.
(EngineCore pid=1992630) INFO 08-26 22:28:30 [kv_cache_utils.py:1319] GPU KV cache size: 17,072 tokens
(EngineCore pid=1992630) INFO 08-26 22:28:30 [kv_cache_utils.py:1324] Maximum concurrency for 4,096 tokens per request: 4.17x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|██████████████████| 35/35 [00:02<00:00, 14.81it/s]
Capturing CUDA graphs (decode, FULL): 100%|█████████████████████████████████████| 19/19 [00:01<00:00, 18.34it/s]
(EngineCore pid=1992630) INFO 08-26 22:28:35 [gpu_model_runner.py:6046] Graph capturing finished in 4 secs, took 0.32 GiB
(EngineCore pid=1992630) INFO 08-26 22:28:35 [gpu_worker.py:597] CUDA graph pool memory: 0.32 GiB (actual), 0.32 GiB (estimated), difference: 0.0 GiB (1.2%).
(EngineCore pid=1992630) INFO 08-26 22:28:35 [core.py:283] init engine (profile, create kv cache, warmup model) took 23.92 seconds
Sliding windows:   0%|                                                                    | 0/1 [00:00<?, ?it/s]2026-08-26 22:28:35,630 - INFO - Async VLLM Generating!
Sliding windows: 100%|████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.50it/s]
(EngineCore pid=1992630) INFO 08-26 22:28:36 [core.py:1210] Shutdown initiated (timeout=0)
(EngineCore pid=1992630) INFO 08-26 22:28:36 [core.py:1233] Shutdown complete
[Result(query=Query(text='how long is life cycle of flea', qid='264014'), candidates=[Candidate(docid='4834547', score=14.971799850463867, doc={'segment': 'The life cycle of a flea can last anywhere from 20 days to an entire year. It depends on how long the flea remains in the dormant stage (eggs, larvae, pupa). Outside influences, such as weather, affect the flea cycle. A female flea can lay around 20 to 25 eggs in one day.'}), Candidate(docid='6641238', score=15.090800285339355, doc={'segment': 'The life cycle of a flea can last anywhere from 20 days to an entire year. It depends on how long the flea remains in the dormant stage (eggs, larvae, pupa). Outside influences, such as weather, affect the flea cycle. A female flea can lay around 20 to 25 eggs in one day. The flea egg stage is the beginning of the flea cycle. This part of the flea cycle represents a little more than one third of the flea population at any given time. Depending on the temperature and humidity of the environment the egg can take from two to six days to hatch.'}), Candidate(docid='96852', score=13.455499649047852, doc={'segment': 'Flea Pupa. The flea larvae spin cocoons around themselves in which they move to the last phase of the flea life cycle and become adult fleas. The larvae can remain in the cocoon anywhere from one week to one year. Temperature is one factor that determines how long it will take for the adult flea to emerge from the cocoon.'}), Candidate(docid='96854', score=14.215100288391113, doc={'segment': "2) The fleas life cycle discussed - the flea life cycle diagram explained in full. 2a) Fleas life cycle 1 - The adult flea lays her eggs on the host animal. 2b) Fleas life cycle 2 - The egg falls off the animal's skin and into the local environment of the host animal. 2c) Fleas life cycle 3 - The flea egg hatches, releasing a first stage (stage 1) flea larva."}), Candidate(docid='5635521', score=13.947500228881836, doc={'segment': 'In appearance, flea larvae can be up to Â¼-inch long and are white (almost see-through) and legless. Larvae make up about 35 percent of the flea population in the average household. If conditions are favorable, the larvae will spin cocoons in about 5-20 days of hatching from their eggs.This leads to the next life stage, called the cocoon or pupae stage.The pupae stage of the flea life cycle accounts for about 10 percent of the flea population in a home.f conditions are favorable, the larvae will spin cocoons in about 5-20 days of hatching from their eggs. This leads to the next life stage, called the cocoon or pupae stage. The pupae stage of the flea life cycle accounts for about 10 percent of the flea population in a home.'}), Candidate(docid='1610712', score=15.780599594116211, doc={'segment': 'To go to our more detailed flea life cycle and flea control page, click here. 1) The flea life cycle diagram - a complete step-by-step diagram of animal host flea infestation; flea reproduction and environmental flea contamination with juvenile flea life cycle stages (eggs, larvae and pupae).'}), Candidate(docid='4239616', score=13.985199928283691, doc={'segment': "The cat flea's primary host is the domestic cat, but it is also the primary flea infesting dogs in most of the world. The cat flea can also maintain its life cycle on other carnivores and on omnivores. Humans can be bitten, though a long-term population of cat fleas cannot be sustained and infest people.However, if the female flea is allowed to feed for 12 consecutive hours on a human, it can lay viable eggs.he cat flea's primary host is the domestic cat, but it is also the primary flea infesting dogs in most of the world. The cat flea can also maintain its life cycle on other carnivores and on omnivores. Humans can be bitten, though a long-term population of cat fleas cannot be sustained and infest people."}), Candidate(docid='5611210', score=13.533599853515625, doc={'segment': "5. Cancel. A flea can live up to a year, but its general lifespan depends on its living conditions, such as the availability of hosts. Find out how long a flea's life cycle can last with tips from a pet industry specialist in this free video on fleas and pest control.Part of the Video Series: Flea Control.ancel. A flea can live up to a year, but its general lifespan depends on its living conditions, such as the availability of hosts. Find out how long a flea's life cycle can last with tips from a pet industry specialist in this free video on fleas and pest control. Part of the Video Series: Flea Control."})], invocations_history=[InferenceInvocation(prompt="You are RankLLM, an intelligent assistant that can rank passages based on their relevancy to the query USER: I will provide you with 8 passages, each indicated by a numerical identifier []. Rank the passages based on their relevance to the search query: how long is life cycle of flea.\n[1] The life cycle of a flea can last anywhere from 20 days to an entire year. It depends on how long the flea remains in the dormant stage (eggs, larvae, pupa). Outside influences, such as weather, affect the flea cycle. A female flea can lay around 20 to 25 eggs in one day.\n[2] The life cycle of a flea can last anywhere from 20 days to an entire year. It depends on how long the flea remains in the dormant stage (eggs, larvae, pupa). Outside influences, such as weather, affect the flea cycle. A female flea can lay around 20 to 25 eggs in one day. The flea egg stage is the beginning of the flea cycle. This part of the flea cycle represents a little more than one third of the flea population at any given time. Depending on the temperature and humidity of the environment the egg can take from two to six days to hatch.\n[3] To go to our more detailed flea life cycle and flea control page, click here. 1) The flea life cycle diagram - a complete step-by-step diagram of animal host flea infestation; flea reproduction and environmental flea contamination with juvenile flea life cycle stages (eggs, larvae and pupae).\n[4] Flea Pupa. The flea larvae spin cocoons around themselves in which they move to the last phase of the flea life cycle and become adult fleas. The larvae can remain in the cocoon anywhere from one week to one year. Temperature is one factor that determines how long it will take for the adult flea to emerge from the cocoon.\n[5] The cat flea's primary host is the domestic cat, but it is also the primary flea infesting dogs in most of the world. The cat flea can also maintain its life cycle on other carnivores and on omnivores. Humans can be bitten, though a long-term population of cat fleas cannot be sustained and infest people.However, if the female flea is allowed to feed for 12 consecutive hours on a human, it can lay viable eggs.he cat flea's primary host is the domestic cat, but it is also the primary flea infesting dogs in most of the world. The cat flea can also maintain its life cycle on other carnivores and on omnivores. Humans can be bitten, though a long-term population of cat fleas cannot be sustained and infest people.\n[6] 5. Cancel. A flea can live up to a year, but its general lifespan depends on its living conditions, such as the availability of hosts. Find out how long a flea's life cycle can last with tips from a pet industry specialist in this free video on fleas and pest control.Part of the Video Series: Flea Control.ancel. A flea can live up to a year, but its general lifespan depends on its living conditions, such as the availability of hosts. Find out how long a flea's life cycle can last with tips from a pet industry specialist in this free video on fleas and pest control. Part of the Video Series: Flea Control.\n[7] 2) The fleas life cycle discussed - the flea life cycle diagram explained in full. 2a) Fleas life cycle 1 - The adult flea lays her eggs on the host animal. 2b) Fleas life cycle 2 - The egg falls off the animal's skin and into the local environment of the host animal. 2c) Fleas life cycle 3 - The flea egg hatches, releasing a first stage (stage 1) flea larva.\n[8] In appearance, flea larvae can be up to ¼-inch long and are white (almost see-through) and legless. Larvae make up about 35 percent of the flea population in the average household. If conditions are favorable, the larvae will spin cocoons in about 5-20 days of hatching from their eggs.This leads to the next life stage, called the cocoon or pupae stage.The pupae stage of the flea life cycle accounts for about 10 percent of the flea population in a home.f conditions are favorable, the larvae will spin cocoons in about 5-20 days of hatching from their eggs. This leads to the next life stage, called the cocoon or pupae stage. The pupae stage of the flea life cycle accounts for about 10 percent of the flea population in a home.\nSearch Query: how long is life cycle of flea.\nRank the 8 passages above based on their relevance to the search query. All the passages should be included and listed using identifiers, in descending order of relevance. The output format should be [] > [], e.g., [2] > [1], Answer concisely and directly and only respond with the ranking results, do not say any word or explain. ASSISTANT:", response=' [1] > [2] > [4] > [7] > [8] > [3] > [5] > [6]', input_token_count=1236, output_token_count=31, reasoning='', token_usage={'prompt_tokens': 1236, 'completion_tokens': 31, 'total_tokens': 1267}, output_validation_regex='r"^\\[\\d+\\]( > \\[\\d+\\])*$"', output_extraction_regex='r"\\[(\\d+)\\]"')])]
```

```bash
uv run pre-commit run --all-files
uv run python -m unittest discover test
```

## Follow-ups

## Checklist Items

Before submitting your pull request, please review these items:

- [ ] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [ ] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [ ] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
