### PR TITLE
Fix LiteLLM backend wiring across CLI and HTTP API

### DIFF
--- a/src/rank_llm/api/runtime.py
+++ b/src/rank_llm/api/runtime.py
@@ -179,12 +179,15 @@ def _merge_config_with_payload(
     payload: dict[str, Any], *, config: ServerConfig
 ) -> ServerConfig:
     overrides = _extract_override_payload(payload)
-    if not overrides:
-        return config
-    effective_config = replace(config, **overrides)
-    if effective_config.use_azure_openai and effective_config.use_openrouter:
+    effective_config = replace(config, **overrides) if overrides else config
+    enabled_backends = [
+        field_name
+        for field_name in ("use_azure_openai", "use_openrouter", "use_litellm")
+        if getattr(effective_config, field_name)
+    ]
+    if len(enabled_backends) > 1:
         raise ValueError(
-            "use_azure_openai and use_openrouter cannot both be true in overrides"
+            "backend selectors cannot be combined: " + ", ".join(enabled_backends)
         )
     return effective_config
 

--- a/src/rank_llm/api/runtime.py
+++ b/src/rank_llm/api/runtime.py
@@ -28,6 +28,7 @@ class ServerConfig:
     print_prompts_responses: bool = False
     use_azure_openai: bool = False
     use_openrouter: bool = False
+    use_litellm: bool = False
     base_url: str = ""
     variable_passages: bool = False
     num_passes: int = 1
@@ -61,6 +62,7 @@ _OVERRIDABLE_FIELDS = {
     "print_prompts_responses",
     "use_azure_openai",
     "use_openrouter",
+    "use_litellm",
     "base_url",
     "variable_passages",
     "num_passes",
@@ -90,6 +92,7 @@ _RERANKER_CACHE_FIELDS = (
     "print_prompts_responses",
     "use_azure_openai",
     "use_openrouter",
+    "use_litellm",
     "base_url",
     "variable_passages",
     "num_passes",
@@ -120,6 +123,7 @@ _OVERRIDE_FIELD_TYPES: dict[str, type[Any]] = {
     "print_prompts_responses": bool,
     "use_azure_openai": bool,
     "use_openrouter": bool,
+    "use_litellm": bool,
     "base_url": str,
     "variable_passages": bool,
     "num_passes": int,
@@ -215,6 +219,7 @@ def initialize_reranker(
             print_prompts_responses=effective_config.print_prompts_responses,
             use_azure_openai=effective_config.use_azure_openai,
             use_openrouter=effective_config.use_openrouter,
+            use_litellm=effective_config.use_litellm,
             base_url=effective_config.base_url or None,
             variable_passages=effective_config.variable_passages,
             num_passes=effective_config.num_passes,
@@ -262,6 +267,7 @@ def run_rerank_request(
         print_prompts_responses=effective_config.print_prompts_responses,
         use_azure_openai=effective_config.use_azure_openai,
         use_openrouter=effective_config.use_openrouter,
+        use_litellm=effective_config.use_litellm,
         base_url=effective_config.base_url,
         variable_passages=effective_config.variable_passages,
         num_passes=effective_config.num_passes,

--- a/src/rank_llm/cli/main.py
+++ b/src/rank_llm/cli/main.py
@@ -623,6 +623,20 @@ def _validate_rerank_backend_flags(args: argparse.Namespace, *, command: str) ->
             command=command,
         )
 
+    enabled_backends = [
+        field_name
+        for field_name in ("use_azure_openai", "use_openrouter", "use_litellm")
+        if getattr(args, field_name, False)
+    ]
+    if len(enabled_backends) > 1:
+        raise CLIError(
+            "backend selectors cannot be combined: " + ", ".join(enabled_backends),
+            exit_code=EXIT_CODES["invalid_arguments"],
+            status="validation_error",
+            error_code="invalid_arguments",
+            command=command,
+        )
+
 
 def _normalize_direct_rerank_input(payload: dict[str, Any]) -> dict[str, Any]:
     query = payload["query"]

--- a/src/rank_llm/cli/operations.py
+++ b/src/rank_llm/cli/operations.py
@@ -312,6 +312,7 @@ def run_mcp_retrieve_and_rerank(
         print_prompts_responses=print_prompts_responses,
         use_azure_openai=use_azure_openai,
         use_openrouter=use_openrouter,
+        use_litellm=use_litellm,
         base_url=base_url or None,
         variable_passages=variable_passages,
         num_passes=num_passes,

--- a/src/rank_llm/rerank/reranker.py
+++ b/src/rank_llm/rerank/reranker.py
@@ -316,6 +316,7 @@ class Reranker:
                 window_size=window_size,
                 stride=stride,
                 batch_size=batch_size,
+                api_base=base_url,
                 max_passage_words=max_passage_words,
                 sampling_kwargs=sampling_kwargs,
             )

--- a/test/rerank/test_rankllm.py
+++ b/test/rerank/test_rankllm.py
@@ -1,7 +1,9 @@
 import unittest
 import warnings
+from unittest.mock import patch
 
 from rank_llm.rerank.rankllm import PromptMode, RankLLM
+from rank_llm.rerank.reranker import Reranker
 
 # A real template so RankLLM.__init__ can build an inference handler.
 _TEMPLATE = "src/rank_llm/rerank/prompt_templates/rank_gpt_template.yaml"
@@ -73,6 +75,23 @@ class TestPromptModeDeprecation(unittest.TestCase):
             w for w in caught if "PromptMode is deprecated" in str(w.message)
         ]
         self.assertEqual(prompt_mode_warnings, [])
+
+
+class TestModelCoordinator(unittest.TestCase):
+    def test_litellm_receives_custom_api_base(self):
+        with patch("rank_llm.rerank.listwise.SafeLiteLLM") as safe_litellm:
+            Reranker.create_model_coordinator(
+                "openai/custom-model",
+                None,
+                False,
+                use_litellm=True,
+                base_url="https://example.invalid/v1",
+            )
+
+        self.assertEqual(
+            safe_litellm.call_args.kwargs["api_base"],
+            "https://example.invalid/v1",
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_cli_http.py
+++ b/test/test_cli_http.py
@@ -1,3 +1,6 @@
+import contextlib
+import io
+import json
 import subprocess
 import unittest
 from importlib.util import find_spec
@@ -118,6 +121,37 @@ class TestCLIHTTP(unittest.TestCase):
         self.assertEqual(return_code, 0)
         self.assertTrue(create_app.call_args.args[0].use_litellm)
         uvicorn_run.assert_called_once()
+
+    def test_serve_http_rejects_conflicting_backend_flags_at_startup(self):
+        from rank_llm.cli.main import main
+
+        stdout = io.StringIO()
+        with (
+            patch("rank_llm.api.app.create_app") as create_app,
+            patch("uvicorn.run") as uvicorn_run,
+            contextlib.redirect_stdout(stdout),
+        ):
+            return_code = main(
+                [
+                    "--output",
+                    "json",
+                    "serve",
+                    "http",
+                    "--model-path",
+                    "model",
+                    "--use-litellm",
+                    "--use-openrouter",
+                ]
+            )
+
+        self.assertEqual(return_code, 2)
+        create_app.assert_not_called()
+        uvicorn_run.assert_not_called()
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["status"], "validation_error")
+        self.assertIn(
+            "backend selectors cannot be combined", payload["errors"][0]["message"]
+        )
 
     def test_rerank_route_reuses_initialized_reranker(self):
         reranker = Mock()

--- a/test/test_cli_http.py
+++ b/test/test_cli_http.py
@@ -75,6 +75,7 @@ class TestCLIHTTP(unittest.TestCase):
                         "model_path": "other-model",
                         "top_k_rerank": 5,
                         "reasoning_effort": "medium",
+                        "use_litellm": True,
                     },
                 },
             )
@@ -84,10 +85,39 @@ class TestCLIHTTP(unittest.TestCase):
         self.assertEqual(effective_config.model_path, "other-model")
         self.assertEqual(effective_config.top_k_rerank, 5)
         self.assertEqual(effective_config.reasoning_effort, "medium")
+        self.assertTrue(effective_config.use_litellm)
         self.assertEqual(mocked.call_args.kwargs["model_path"], "other-model")
         self.assertEqual(mocked.call_args.kwargs["top_k_rerank"], 5)
         self.assertEqual(mocked.call_args.kwargs["reasoning_effort"], "medium")
+        self.assertTrue(mocked.call_args.kwargs["use_litellm"])
         self.assertIs(mocked.call_args.kwargs["reranker"], reranker)
+
+    def test_initialize_reranker_forwards_litellm_config(self):
+        from rank_llm.api.runtime import initialize_reranker
+
+        config = ServerConfig(model_path="openai/gpt-4o-mini", use_litellm=True)
+
+        with patch("rank_llm.api.runtime.Reranker") as reranker_class:
+            reranker_class.create_model_coordinator.return_value = object()
+            initialize_reranker(config)
+
+        kwargs = reranker_class.create_model_coordinator.call_args.kwargs
+        self.assertTrue(kwargs["use_litellm"])
+
+    def test_serve_http_with_litellm_reaches_app_creation(self):
+        from rank_llm.cli.main import main
+
+        with (
+            patch("rank_llm.api.app.create_app", return_value=object()) as create_app,
+            patch("uvicorn.run") as uvicorn_run,
+        ):
+            return_code = main(
+                ["serve", "http", "--model-path", "model", "--use-litellm"]
+            )
+
+        self.assertEqual(return_code, 0)
+        self.assertTrue(create_app.call_args.args[0].use_litellm)
+        uvicorn_run.assert_called_once()
 
     def test_rerank_route_reuses_initialized_reranker(self):
         reranker = Mock()

--- a/test/test_cli_http.py
+++ b/test/test_cli_http.py
@@ -203,6 +203,50 @@ class TestCLIHTTP(unittest.TestCase):
         payload = response.json()
         self.assertEqual(payload["status"], "validation_error")
 
+    def test_rerank_route_rejects_conflicting_litellm_backends(self):
+        cases = [
+            (
+                ServerConfig(model_path="model"),
+                {"use_openrouter": True, "use_litellm": True},
+            ),
+            (
+                ServerConfig(model_path="model"),
+                {"use_azure_openai": True, "use_litellm": True},
+            ),
+            (
+                ServerConfig(model_path="model", use_openrouter=True),
+                {"use_litellm": True},
+            ),
+            (
+                ServerConfig(model_path="model", use_litellm=True),
+                {"use_azure_openai": True},
+            ),
+            (
+                ServerConfig(model_path="model", use_openrouter=True, use_litellm=True),
+                {},
+            ),
+        ]
+
+        for config, overrides in cases:
+            with self.subTest(config=config, overrides=overrides):
+                client = TestClient(create_app(config))
+                response = client.post(
+                    "/v1/rerank",
+                    json={
+                        "query": "cats",
+                        "candidates": ["doc one"],
+                        "overrides": overrides,
+                    },
+                )
+
+                self.assertEqual(response.status_code, 400)
+                payload = response.json()
+                self.assertEqual(payload["status"], "validation_error")
+                self.assertIn(
+                    "backend selectors cannot be combined",
+                    payload["errors"][0]["message"],
+                )
+
     def test_rerank_route_returns_400_for_invalid_override_types(self):
         client = TestClient(create_app(ServerConfig(model_path="model")))
         response = client.post(

--- a/test/test_cli_operations.py
+++ b/test/test_cli_operations.py
@@ -94,6 +94,7 @@ class TestCLIOperations(unittest.TestCase):
             max_queries=-1,
             reasoning_effort="high",
             max_passage_words=222,
+            use_litellm=True,
             runner=runner,
             device_resolver=lambda: "cpu",
         )
@@ -109,6 +110,7 @@ class TestCLIOperations(unittest.TestCase):
         self.assertEqual(kwargs["device"], "cpu")
         self.assertEqual(kwargs["reasoning_effort"], "high")
         self.assertEqual(kwargs["max_passage_words"], 222)
+        self.assertTrue(kwargs["use_litellm"])
 
     def test_run_evaluate_aggregate_uses_custom_runner(self):
         runner = Mock()

--- a/test/test_cli_rerank_command.py
+++ b/test/test_cli_rerank_command.py
@@ -98,6 +98,61 @@ class TestCLIRerankCommand(unittest.TestCase):
         envelope = json.loads(stdout.getvalue())
         self.assertEqual(envelope["artifacts"][0]["value"], [{"direct": True}])
 
+    def test_rerank_rejects_conflicting_backend_flags(self):
+        payload = '{"query":"cats","candidates":["doc one"]}'
+        conflicting_flags = (
+            ("--use-litellm", "--use-openrouter"),
+            ("--use-litellm", "--use-azure-openai"),
+            ("--use-openrouter", "--use-azure-openai"),
+        )
+
+        for first_flag, second_flag in conflicting_flags:
+            with self.subTest(first_flag=first_flag, second_flag=second_flag):
+                stdout = io.StringIO()
+                with (
+                    patch("rank_llm.cli.main.run_mcp_rerank") as mocked,
+                    contextlib.redirect_stdout(stdout),
+                ):
+                    exit_code = main(
+                        [
+                            "--output",
+                            "json",
+                            "rerank",
+                            "--model-path",
+                            "model",
+                            "--input-json",
+                            payload,
+                            first_flag,
+                            second_flag,
+                        ]
+                    )
+
+                self.assertEqual(exit_code, 2)
+                mocked.assert_not_called()
+                response = json.loads(stdout.getvalue())
+                self.assertEqual(response["status"], "validation_error")
+                self.assertIn(
+                    "backend selectors cannot be combined",
+                    response["errors"][0]["message"],
+                )
+
+    def test_rerank_accepts_single_backend_flag(self):
+        payload = '{"query":"cats","candidates":["doc one"]}'
+        with patch("rank_llm.cli.main.run_mcp_rerank", return_value=[]) as mocked:
+            exit_code = main(
+                [
+                    "rerank",
+                    "--model-path",
+                    "model",
+                    "--input-json",
+                    payload,
+                    "--use-litellm",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0)
+        mocked.assert_called_once()
+
     def test_rerank_stdin_mode_uses_inline_handler(self):
         stdout = io.StringIO()
         stdin = io.StringIO(


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

Please provide the reference to issue this PR is addressing (# followed by the issue number). If there is no associated issue, write "N/A".

ref: N/A - this bug was found while playing around with agents, and a fix is being directly proposed here

## Summary

Fix LiteLLM backend selection and configuration across HTTP serving and retrieval-based reranking.

- Add `use_litellm` to the HTTP `ServerConfig`.
- Support it in request overrides, cache keys, coordinator initialization, and request execution.
- Forward `use_litellm` through dataset and requests-file reranking.
- Forward `--base-url` to `SafeLiteLLM` as `api_base`.
- Reject HTTP configurations that enable multiple backend selectors.
- Add regression tests for startup, propagation, custom endpoints, and conflicting overrides.

## Why

This PR fixes several LiteLLM integration problems:

- `rank-llm serve http` crashed because `use_litellm` was passed to `ServerConfig`, but the field did
not exist.
- Dataset and requests-file commands accepted `--use-litellm` but silently dropped it.
- LiteLLM ignored `--base-url`, causing custom endpoint requests to use the provider default.
- Conflicting backend selectors were accepted, allowing branch order to silently select a different
backend than requested.

## Validation

- HTTP suite: 15 tests passed.
- Reranker and CLI operation tests passed.
- Ruff lint and formatting checks passed.
- Manually verified requests-file LiteLLM backend selection without an API call using --max-queries 0.

## Follow-ups


## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
