### PR TITLE
Restore rank-llm rerank in the Colab onboarding guide.

### DIFF
--- a/docs/install-colab-cli.md
+++ b/docs/install-colab-cli.md
@@ -146,10 +146,10 @@ Inside that shell, run the pipeline:
 ```bash
 cd /content/rank_llm
 
-python src/rank_llm/scripts/run_rank_llm.py \
-  --model_path=castorini/monot5-base-msmarco \
-  --top_k_candidates=100 --dataset=dl20 \
-  --retrieval_method=bm25 --context_size=512
+rank-llm rerank \
+  --model-path=castorini/monot5-base-msmarco \
+  --top-k-candidates=100 --dataset=dl20 \
+  --retrieval-method=bm25 --context-size=512
 ```
 
 Three things happen, and you'll see each in the output:


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

#430

ref: 

## Summary

- The Colab monoT5 command on main still uses run_rank_llm.py, I switched it to rank-llm rerank so it matches #429.

## Why

Cleaning up missed `run_rank_llm.py` command missed from previous PR (#429).

## Validation

```bash
rank-llm rerank \
  --model-path=castorini/monot5-base-msmarco \
  --top-k-candidates=100 --dataset=dl20 \
  --retrieval-method=bm25 --context-size=512
```

## Follow-ups

- None left for onboarding.

## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
