### PR TITLE
Add support for DL19 in onboarding-rz.md and onboarding-first.md

### DIFF
--- a/docs/onboarding-first.md
+++ b/docs/onboarding-first.md
@@ -17,14 +17,14 @@ Before starting, work through [install-colab-cli.md](install-colab-cli.md), whic
 - Understand the motivation and architecture of multi-stage retrieval.
 - Understand listwise reranking with LLMs, using sliding windows.
 - Understand how FIRST speeds up the reranking process by leveraging logits.
-- Be able to run end-to-end multi-stage retrieval pipeline with RankZephyr and FirstMistral.
+- Be able to run end-to-end multi-stage retrieval pipelines with RankZephyr and FirstMistral.
 
 In this guide, we will focus on the listwise approach.
 For more information about pointwise and pairwise, one can refer to [Zhuang et al. (2024)](https://arxiv.org/abs/2310.14122) and [Qin et al. (2024)](https://arxiv.org/abs/2306.17563).
 
 > Note: as you can tell from the years of the citations, reranking with LLMs is quite a recent topic; indeed, this is still a highly active area of research. Thus, beware that the "knowledge-cutoff" of this guide is Jan 2025.
 
-## Understanding FIRST: First-Roken Reranking
+## Understanding FIRST: First-Token Reranking
 
 FIRST (Faster Improved Listwise Reranking with Single Token Decoding) is a novel approach to reranking with LLMs that is up to 42% faster to inference than the "traditional" approach we have presented above for RankZephyr.
 
@@ -39,13 +39,46 @@ For more information about FIRST, refer to [Reddy et al. (2024)](https://arxiv.o
 [FirstMistral](https://arxiv.org/abs/2411.05508) is an LLM fine-tuned for listwise reranking using the FIRST approach.
 Similar to RankZephyr, we will run an end-to-end multi-stage retrieval with FirstMistral.
 
-Assuming that necessary rank_llm installation steps to run RankZephyr have been performed, one can use the following command to run FirstMistral:
-
-If you are running on Colab, follow the same setup steps from the [RankZephyr lesson](./onboarding-rz.md#running-rankzephyr-on-a-colab-gpu) (Colab CLI, A100, the vLLM/CUDA 12.8 pins, and JDK 21). The environment is identical; only the run command below changes.
-
-
+If you are running on Colab, follow the same setup steps from the [RankZephyr lesson](./onboarding-rz.md#running-rankzephyr-on-a-colab-gpu) (Colab CLI, A100, the vLLM/CUDA 12.8 pins, and JDK 21). The environment is identical; only the run commands below change.
 
 **Before running:** pre-seed the qrels as shown in the [RankZephyr lesson](./onboarding-rz.md) so evaluation doesn't hit Anserini's dead qrels download URL.
+
+Assuming that necessary rank_llm installation steps to run RankZephyr have been performed, one can use the following commands to run FirstMistral on TREC DL19 and DL20:
+
+---
+
+#### DL19
+
+```bash
+rank-llm rerank \
+  --model-path=castorini/first_mistral \
+  --top-k-candidates=100 \
+  --dataset=dl19 \
+  --retrieval-method=SPLADE++_EnsembleDistil_ONNX \
+  --prompt-template-path=src/rank_llm/rerank/prompt_templates/rank_zephyr_alpha_template.yaml \
+  --context-size=4096 \
+  --variable-passages \
+  --use-logits \
+  --use-alpha \
+  --num-gpus 1
+```
+
+The results should be something like:
+
+```text
+Results:
+ndcg_cut_10             all     0.7880
+```
+
+The command above performs first-stage retrieval with SPLADE to get the initial 100 candidates, followed by listwise reranking using FIRST with FirstMistral.
+
+If you wish to compare FIRST's speed with traditional listwise reranking, omit the `--use-logits` and `--use-alpha` flags to perform traditional listwise reranking.
+
+---
+
+#### DL20
+
+Now run the same pipeline on DL20:
 
 ```bash
 rank-llm rerank \
@@ -68,9 +101,9 @@ Results:
 ndcg_cut_10             all     0.7851
 ```
 
-This above performs first-stage retrieval with SPLADE to get the initial 100 candidates, followed by listwise reranking using FIRST with FirstMistral.
+Running the same pipeline on DL20 gives a nDCG@10 score in a similar range, and now we have completed the FirstMistral experiments on both datasets.
 
-If you wish to compare FIRST's speed with traditional listwise reranking, omit the `--use-logits` and `--use-alpha` flags to perform traditional listwise reranking.
+---
 
 That is all for this guide!
 A reminder that this is just a gentle introduction, and the field is still largely an active area of research; we welcome you to join us in exploring the exciting possibilities of reranking with LLMs!
@@ -79,7 +112,11 @@ A reminder that this is just a gentle introduction, and the field is still large
 
 The experiments in this guide could slightly vary in results due to the intrinsic randomness of LLMs, and particularly the `vLLM` library.
 Thus, in addition to a log entry like the previous steps of the onboarding path, we also request that you add an entry to the table below indicating the precise numbers you obtained from running the experiments; we would like to keep track of these to better understand the variance from `vLLM`.
-More specifically, we are interested in the `ndcg_cut_10` score for the RankZephyr and FirstMistral models on the DL20 dataset–the two experiments you have just completed.
+More specifically, we are interested in the `ndcg_cut_10` score for FirstMistral on both the TREC DL19 and DL20 datasets—the two experiments you have just completed.
+
+| FirstMistral DL19 | Frequency |
+|-------------------|-----------|
+| 0.7880            | 1         |
 
 | FirstMistral DL20 | Frequency |
 |-------------------|-----------|
@@ -95,10 +132,10 @@ More specifically, we are interested in the `ndcg_cut_10` score for the RankZeph
 | 0.7842            | 1         |
 | 0.7829            | 1         |
 
-If your result is present in the table above, please increase its frequency by 1.
-If your result is not present, add a new row to the table with frequency 1.
+For each result, if it is present in the corresponding table above, please increase its frequency by 1.
+If a result is not present, add a new row (in sorted order) to the corresponding table with frequency 1.
 
-After editing the table above, add a log entry here as well like the previous guides:
+After editing the tables above, add a log entry here as well like the previous guides:
 
 + Results reproduced by [@wu-ming233](https://github.com/wu-ming233) on 2025-01-08 (commit [`dac99f7`](https://github.com/castorini/rank_llm/commit/c908de0423747a3863ca288b072e4580b3a3adef))
 + Results reproduced by [@b8zhong](https://github.com/b8zhong) on 2025-02-03 (commit [`c908de0`](https://github.com/castorini/rank_llm/commit/c908de0423747a3863ca288b072e4580b3a3adef))

--- a/docs/onboarding-first.md
+++ b/docs/onboarding-first.md
@@ -20,6 +20,7 @@ Before starting, work through [install-colab-cli.md](install-colab-cli.md), whic
 - Be able to run end-to-end multi-stage retrieval pipelines with RankZephyr and FirstMistral.
 
 In this guide, we will focus on the listwise approach.
+Throughout the process, you will reproduce the SPLADE++ EnsembleDistil → FirstMistral results from Table 3 of [this paper](https://arxiv.org/pdf/2411.05508), on both TREC DL19 and DL20.
 For more information about pointwise and pairwise, one can refer to [Zhuang et al. (2024)](https://arxiv.org/abs/2310.14122) and [Qin et al. (2024)](https://arxiv.org/abs/2306.17563).
 
 > Note: as you can tell from the years of the citations, reranking with LLMs is quite a recent topic; indeed, this is still a highly active area of research. Thus, beware that the "knowledge-cutoff" of this guide is Jan 2025.
@@ -35,6 +36,12 @@ For example, if the probabilities of ranking documents 1, 2, 3 as the top docume
 For more information about FIRST, refer to [Reddy et al. (2024)](https://arxiv.org/abs/2406.15657) if you are interested.
 
 ## Reranking with FirstMistral
+
+The target of this reproduction is from Table 3 of [this paper](https://arxiv.org/pdf/2411.05508), which reports SPLADE++ EnsembleDistil → FirstMistral results for TREC DL19 and DL20.
+
+**Note:** 
+RankLLM and its dependencies have changed since the experiments demonstrated in the paper, so reproducing the same multi-stage retrieval pipeline may result in different values from what was originally reported in Table 3. 
+In particular, the current DL19 result is higher than the 0.7678 reported in Table 3.
 
 [FirstMistral](https://arxiv.org/abs/2411.05508) is an LLM fine-tuned for listwise reranking using the FIRST approach.
 Similar to RankZephyr, we will run an end-to-end multi-stage retrieval with FirstMistral.
@@ -70,6 +77,8 @@ Results:
 ndcg_cut_10             all     0.7880
 ```
 
+As noted above, this result is expected to be higher than the 0.7678 reported in Table 3.
+
 The command above performs first-stage retrieval with SPLADE to get the initial 100 candidates, followed by listwise reranking using FIRST with FirstMistral.
 
 If you wish to compare FIRST's speed with traditional listwise reranking, omit the `--use-logits` and `--use-alpha` flags to perform traditional listwise reranking.
@@ -101,7 +110,7 @@ Results:
 ndcg_cut_10             all     0.7851
 ```
 
-Running the same pipeline on DL20 gives a nDCG@10 score in a similar range, and now we have completed the FirstMistral experiments on both datasets.
+Running the same pipeline on DL20 gives an nDCG@10 score quite close to the results reported in the paper.
 
 ---
 

--- a/docs/onboarding-rz.md
+++ b/docs/onboarding-rz.md
@@ -17,7 +17,7 @@ Before starting, work through [install-colab-cli.md](install-colab-cli.md), whic
 - Understand the motivation and architecture of multi-stage retrieval.
 - Understand listwise reranking with LLMs, using sliding windows.
 - Understand how FIRST speeds up the reranking process by leveraging logits.
-- Be able to run end-to-end multi-stage retrieval pipeline with RankZephyr and FirstMistral.
+- Be able to run end-to-end multi-stage retrieval pipelines with RankZephyr and FirstMistral.
 
 In this guide, we will focus on the listwise approach.
 For more information about pointwise and pairwise, one can refer to [Zhuang et al. (2024)](https://arxiv.org/abs/2310.14122) and [Qin et al. (2024)](https://arxiv.org/abs/2306.17563).
@@ -90,7 +90,7 @@ In practice, we often use a window size of 20 and a stride of 10.
 ## Reranking with RankZephyr
 
 [RankZephyr](https://huggingface.co/castorini/rank_zephyr_7b_v1_full) is an LLM specifically fine-tuned for listwise reranking, led by [Pradeep et. al (2023)](https://arxiv.org/abs/2312.02724) at the University of Waterloo.
-We will run end-to-end multi-stage retrieval pipeline with RankZephyr, realizing the listwise reranking with sliding window mechanism as described above.
+We will run end-to-end multi-stage retrieval pipeline with RankZephyr on both TREC DL19 and DL20 datasets, realizing the listwise reranking with sliding window mechanism as described above.
 Note that this will require a GPU with **at least 16GB of VRAM**.
 
 If you are short of GPUs, we recommend purchasing a [Google Colab Pro](https://colab.research.google.com/) for $13.99 CAD.
@@ -154,7 +154,37 @@ export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
 
 Setup is done. Stay in this console session for the actual run below — don't stop the runtime yet.
 
-#### Running the RankZephyr Model
+---
+
+#### Running the RankZephyr Model on DL19
+
+We can run the RankZephyr model with the command:
+
+```bash
+rank-llm rerank \
+  --model-path=castorini/rank_zephyr_7b_v1_full \
+  --top-k-candidates=100 \
+  --dataset=dl19 \
+  --retrieval-method=SPLADE++_EnsembleDistil_ONNX \
+  --prompt-template-path=src/rank_llm/rerank/prompt_templates/rank_zephyr_template.yaml  --context-size=4096 --variable-passages
+```
+
+The results should be something like:
+
+```text
+Results:
+ndcg_cut_10             all     0.7798
+```
+
+Note that the result you get may vary slightly from the number above.
+
+_Where is the first-stage retrieval?_
+It is hidden in the `--retrieval-method=SPLADE++_EnsembleDistil_ONNX` flag.
+We are using the [SPLADE](https://www.pinecone.io/learn/splade/) model as our sparse first-stage retriever, retrieving the top 100 candidates, followed by the RankZephyr model to rerank these 100 candidates.
+
+---
+
+#### Running the RankZephyr Model on DL20
 
 We can run the RankZephyr model with the command:
 
@@ -174,11 +204,9 @@ Results:
 ndcg_cut_10             all     0.8201
 ```
 
-Note that the result you get may vary slightly with the number above.
+Your result should again be close to the number above, although it may vary slightly between runs.
 
-_Where is the first-stage retrieval?_
-It is hidden in the `--retrieval-method=SPLADE++_EnsembleDistil_ONNX` flag.
-We are using the [SPLADE](https://www.pinecone.io/learn/splade/) model as our sparse first-stage retriever, retrieving the top 100 candidates, followed by the RankZephyr model to rerank these 100 candidates.
+---
 
 Before leaving the VM, exit the console:
 
@@ -200,8 +228,12 @@ Go to [the lesson on the FIRST model](./onboarding-first.md) next.
 ## Reproduction Log[*](https://github.com/castorini/pyserini/blob/master/docs/reproducibility.md)
 
 The experiments in this guide could slightly vary in results due to the intrinsic randomness of LLMs, and particularly the `vLLM` library.
-Thus, in addition to a log entry like the previous steps of the onboarding path, we also request that you add an entry to the table below indicating the precise numbers you obtained from running the experiments; we would like to keep track of these to better understand the variance from `vLLM`.
-More specifically, we are interested in the `ndcg_cut_10` score for the RankZephyr and FirstMistral models on the DL20 dataset–the two experiments you have just completed.
+Thus, in addition to a log entry like the previous steps of the onboarding path, we also request that you add an entry to each table below indicating the precise numbers you obtained from running the experiments; we would like to keep track of these to better understand the variance from `vLLM`.
+More specifically, we are interested in the `ndcg_cut_10` score for RankZephyr on both the TREC DL19 and DL20 datasets—the two experiments you have just completed.
+
+| RankZephyr DL19 | Frequency |
+|-----------------|-----------|
+| 0.7798          | 1         |
 
 | RankZephyr DL20 | Frequency |
 |-----------------|-----------|
@@ -215,10 +247,10 @@ More specifically, we are interested in the `ndcg_cut_10` score for the RankZeph
 | 0.8151          | 1         |
 | 0.8144          | 2         |
 
-If your result is present in the table above, please increase its frequency by 1.
-If your result is not present, add a new row (in sorted order) to the table with frequency 1.
+For each result, if it is present in the corresponding table above, please increase its frequency by 1. 
+If a result is not present, add a new row (in sorted order) to the corresponding table with frequency 1.
 
-After editing the table above, add a log entry here as well like the previous guides:
+After editing the tables above, add a log entry here as well like the previous guides:
 
 + Results reproduced by [@wu-ming233](https://github.com/wu-ming233) on 2025-01-08 (commit [`dac99f7`](https://github.com/castorini/rank_llm/commit/c908de0423747a3863ca288b072e4580b3a3adef))
 + Results reproduced by [@b8zhong](https://github.com/b8zhong) on 2025-02-03 (commit [`c908de0`](https://github.com/castorini/rank_llm/commit/c908de0423747a3863ca288b072e4580b3a3adef))

--- a/docs/onboarding-rz.md
+++ b/docs/onboarding-rz.md
@@ -20,6 +20,7 @@ Before starting, work through [install-colab-cli.md](install-colab-cli.md), whic
 - Be able to run end-to-end multi-stage retrieval pipelines with RankZephyr and FirstMistral.
 
 In this guide, we will focus on the listwise approach.
+Throughout the process, you will reproduce the SPLADE++ ED → RankZephyr results from Table 1, row (7) of [this paper](https://arxiv.org/pdf/2312.02724), on both TREC DL19 and DL20.
 For more information about pointwise and pairwise, one can refer to [Zhuang et al. (2024)](https://arxiv.org/abs/2310.14122) and [Qin et al. (2024)](https://arxiv.org/abs/2306.17563).
 
 > Note: as you can tell from the years of the citations, reranking with LLMs is quite a recent topic; indeed, this is still a highly active area of research. Thus, beware that the "knowledge-cutoff" of this guide is Jan 2025.
@@ -89,8 +90,10 @@ In practice, we often use a window size of 20 and a stride of 10.
 
 ## Reranking with RankZephyr
 
+The target of this reproduction is from Table 1, row (7) of [this paper](https://arxiv.org/pdf/2312.02724), which reports SPLADE++ ED → RankZephyr results for TREC DL19 and DL20.
+
 [RankZephyr](https://huggingface.co/castorini/rank_zephyr_7b_v1_full) is an LLM specifically fine-tuned for listwise reranking, led by [Pradeep et. al (2023)](https://arxiv.org/abs/2312.02724) at the University of Waterloo.
-We will run end-to-end multi-stage retrieval pipeline with RankZephyr on both TREC DL19 and DL20 datasets, realizing the listwise reranking with sliding window mechanism as described above.
+We will run end-to-end multi-stage retrieval pipelines with RankZephyr on both TREC DL19 and DL20 datasets, realizing the listwise reranking with sliding window mechanism as described above.
 Note that this will require a GPU with **at least 16GB of VRAM**.
 
 If you are short of GPUs, we recommend purchasing a [Google Colab Pro](https://colab.research.google.com/) for $13.99 CAD.
@@ -176,7 +179,7 @@ Results:
 ndcg_cut_10             all     0.7798
 ```
 
-Note that the result you get may vary slightly from the number above.
+This result should align very closely with the nDCG@10 reported for DL19 in Table 1, row (7), although it may vary slightly between runs.
 
 _Where is the first-stage retrieval?_
 It is hidden in the `--retrieval-method=SPLADE++_EnsembleDistil_ONNX` flag.
@@ -204,7 +207,7 @@ Results:
 ndcg_cut_10             all     0.8201
 ```
 
-Your result should again be close to the number above, although it may vary slightly between runs.
+This result should similarly closely reproduce the nDCG@10 reported for DL20 in Table 1, row(7), although it may vary slightly between runs.
 
 ---
 


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

Please provide the reference to issue this PR is addressing (# followed by the issue number). If there is no associated issue, write "N/A".

ref: #431 

## Summary

- Add a dedicated section on running a multi-stage retrieval pipeline on TREC DL19 for both RankZephyr and FirstMistral onboarding docs
- Add DL19 result examples and separate DL19 reproduction results tables alongside existing DL20 ones

## Why

Currently, both guides only walk through DL20, even though the same pipelines can be easily run on TREC DL19 as well. Adding DL19 gives onboarding contributors more opportunities to reproduce results, and gives us more data to track vLLM variance on.

## Validation

List the exact commands you ran, for example:

```bash
uv run pre-commit run --all-files
uv run python -m unittest discover test
```
```
rank-llm rerank \
  --model-path=castorini/rank_zephyr_7b_v1_full \
  --top-k-candidates=100 \
  --dataset=dl19 \
  --retrieval-method=SPLADE++_EnsembleDistil_ONNX \
  --prompt-template-path=src/rank_llm/rerank/prompt_templates/rank_zephyr_template.yaml  --context-size=4096 --variable-passages

rank-llm rerank \
  --model-path=castorini/first_mistral \
  --top-k-candidates=100 \
  --dataset=dl19 \
  --retrieval-method=SPLADE++_EnsembleDistil_ONNX \
  --prompt-template-path=src/rank_llm/rerank/prompt_templates/rank_zephyr_alpha_template.yaml \
  --context-size=4096 \
  --variable-passages \
  --use-logits \
  --use-alpha \
  --num-gpus 1
```

## Follow-ups

- I considered explicitly referencing some of the earlier papers for both RankZephyr and FirstMistral in their respective onboarding docs like we did for monoT5 in [install-colab-cli.md](https://github.com/castorini/rank_llm/blob/main/docs/install-colab-cli.md)
- However, through reproducing the results on both DL19 and DL20 a few more times in [onboarding-first.md](https://github.com/castorini/rank_llm/blob/main/docs/onboarding-first.md), I realized that the numbers were not quite aligned with the results in [section 5.5 here](https://arxiv.org/html/2411.05508v1)
   - Not sure if this was an intentional update / bug
- Though, the results in [onboarding-rz.md](https://github.com/castorini/rank_llm/blob/main/docs/onboarding-rz.md) align nicely with [Table 1, row  (7) here](https://arxiv.org/pdf/2312.02724)
- So I'm wondering if I should either add references for both guides / only for RankZephyr / leave both out completely?

## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
