### PR TITLE
feature/parameterize e2e demos

### DIFF
--- a/src/rank_llm/demo/rerank_nvidia_openrouter.py
+++ b/src/rank_llm/demo/rerank_nvidia_openrouter.py
@@ -3,6 +3,7 @@ NVIDIA-Nemotron-Nano-9B-v2 reranker using OpenRouter
 Based on OpenRouter integration in commit 55d5c1f4a49080e92af1b19a184ea57982ae9f8b
 """
 
+import argparse
 import os
 import sys
 from importlib.resources import files
@@ -13,68 +14,192 @@ parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
-from rank_llm.data import DataWriter
+from rank_llm.analysis.response_analysis import ResponseAnalyzer
+from rank_llm.data import DataWriter, Result
+from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker, get_openrouter_api_key
 from rank_llm.rerank.listwise import SafeOpenai
-from rank_llm.retrieve import Retriever
+from rank_llm.retrieve import TOPICS, Retriever
 
-# By default uses BM25 for retrieval
-dataset_name = "dl19"
-requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-model = "nvidia/nemotron-nano-9b-v2:free"
-print(f"Testing {len(requests)} queries")
 
-# Test with thinking
-thinking_coordinator = SafeOpenai(
-    model,
-    4096,
-    keys=get_openrouter_api_key(),
-    base_url="https://openrouter.ai/api/v1/",
-    prompt_template_path=(TEMPLATES / "nemotron_thinking_template.yaml"),
-)
-thinking_reranker = Reranker(thinking_coordinator)
-print(f"Using {model} with thinking mode")
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
 
-thinking_results = thinking_reranker.rerank_batch(
-    requests, populate_invocations_history=True
-)
 
-# Save thinking results
-writer = DataWriter(thinking_results)
-Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-writer.write_in_jsonl_format("demo_outputs/nemotron_thinking_results.jsonl")
-writer.write_in_trec_eval_format("demo_outputs/nemotron_thinking_results.txt")
-writer.write_inference_invocations_history(
-    "demo_outputs/nemotron_thinking_invocations.json"
-)
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
 
-print("Thinking mode results saved")
 
-# Test without thinking
-non_thinking_coordinator = SafeOpenai(
-    model,
-    4096,
-    keys=get_openrouter_api_key(),
-    base_url="https://openrouter.ai/api/v1/",
-    prompt_template_path=(TEMPLATES / "nemotron_non_thinking_template.yaml"),
-)
-non_thinking_reranker = Reranker(non_thinking_coordinator)
-print(f"Using {model} with non-thinking mode")
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise NVIDIA Nemotron reranking through the OpenRouter API."
+    )
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with prebuilt index (default: dl19).",
+    )
+    p.add_argument(
+        "--model",
+        default="nvidia/nemotron-nano-9b-v2:free",
+        help="OpenRouter model id (default: nvidia/nemotron-nano-9b-v2:free).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size for the model (default: 4096).",
+    )
+    p.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--thinking",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use the Nemotron thinking prompt template (--thinking / --no-thinking; default: enabled).",
+    )
+    p.add_argument(
+        "--base-url",
+        default="https://openrouter.ai/api/v1/",
+        help="OpenAI-compatible OpenRouter base URL.",
+    )
+    p.add_argument(
+        "--prompt-template-path",
+        default=None,
+        help=(
+            "Path to a custom prompt-template YAML file. Defaults to the packaged "
+            "Nemotron template for the selected thinking mode."
+        ),
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    args = p.parse_args()
 
-non_thinking_results = non_thinking_reranker.rerank_batch(
-    requests, populate_invocations_history=True
-)
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
 
-# Save non-thinking results
-writer = DataWriter(non_thinking_results)
-writer.write_in_jsonl_format("demo_outputs/nemotron_non_thinking_results.jsonl")
-writer.write_in_trec_eval_format("demo_outputs/nemotron_non_thinking_results.txt")
-writer.write_inference_invocations_history(
-    "demo_outputs/nemotron_non_thinking_invocations.json"
-)
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
 
-print("Non-thinking mode results saved")
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
 
-print("Results saved to demo_outputs/")
+    TEMPLATES = files("rank_llm.rerank.prompt_templates")
+    prompt_template_path = args.prompt_template_path
+
+    if prompt_template_path is None:
+        if args.thinking:
+            prompt_template_path = TEMPLATES / "nemotron_thinking_template.yaml"
+        else:
+            prompt_template_path = TEMPLATES / "nemotron_non_thinking_template.yaml"
+
+    coordinator = SafeOpenai(
+        model=args.model,
+        context_size=args.context_size,
+        prompt_template_path=prompt_template_path,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        keys=get_openrouter_api_key(),
+        base_url=args.base_url,
+        max_passage_words=args.max_passage_words,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
+    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    _print_sample(rerank_results)
+
+    analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=False)
+    error_counts = analyzer.count_errors()
+    print(error_counts.__repr__())
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
+
+    model_tag = args.model.split("/")[-1].replace(":", "-").lower()
+    if args.thinking:
+        model_tag += "-thinking"
+    else:
+        model_tag += "-non-thinking"
+
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_openrouter.py
+++ b/src/rank_llm/demo/rerank_openrouter.py
@@ -107,11 +107,6 @@ def main() -> None:
         ),
     )
     parser.add_argument(
-        "--reasoning-effort",
-        default=None,
-        help="Optional reasoning effort passed to models that support it.",
-    )
-    parser.add_argument(
         "--output-dir",
         default=None,
         help="Output directory. When set, outputs go to "
@@ -153,7 +148,6 @@ def main() -> None:
         batch_size=args.batch_size,
         keys=get_openrouter_api_key(),
         base_url=args.base_url,
-        reasoning_effort=args.reasoning_effort,
         max_passage_words=args.max_passage_words,
     )
     reranker = Reranker(coordinator)

--- a/src/rank_llm/demo/rerank_openrouter.py
+++ b/src/rank_llm/demo/rerank_openrouter.py
@@ -48,8 +48,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--model",
-        default="minimax/minimax-m2:free",
-        help="OpenRouter model id (default: minimax/minimax-m2:free).",
+        default="minimax/minimax-m2",
+        help="OpenRouter model id (default: minimax/minimax-m2).",
     )
     parser.add_argument(
         "--k",

--- a/src/rank_llm/demo/rerank_openrouter.py
+++ b/src/rank_llm/demo/rerank_openrouter.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 from importlib.resources import files
@@ -8,33 +9,185 @@ parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
-from rank_llm.data import DataWriter
+from rank_llm.analysis.response_analysis import ResponseAnalyzer
+from rank_llm.data import DataWriter, Result
+from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker, get_openrouter_api_key
 from rank_llm.rerank.listwise import SafeOpenai
-from rank_llm.retrieve import Retriever
+from rank_llm.retrieve import TOPICS, Retriever
 
-# By default uses BM25 for retrieval
-dataset_name = "dl19"
-requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
-model_coordinator = SafeOpenai(
-    "minimax/minimax-m2:free",
-    4096,
-    keys=get_openrouter_api_key(),
-    base_url="https://openrouter.ai/api/v1/",
-    api_type="openai",
-    prompt_template_path=(TEMPLATES / "rank_zephyr_template.yaml"),
-)
-reranker = Reranker(model_coordinator)
-kwargs = {"populate_invocations_history": True}
-rerank_results = reranker.rerank_batch(requests, **kwargs)
-print(rerank_results)
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-# write rerank results
-writer = DataWriter(rerank_results)
-Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-writer.write_in_jsonl_format("demo_outputs/rerank_results.jsonl")
-writer.write_in_trec_eval_format("demo_outputs/rerank_results.txt")
-writer.write_inference_invocations_history(
-    "demo_outputs/inference_invocations_history.json"
-)
+
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for result in results[:max_queries]:
+        print(f"qid={result.query.qid} text={result.query.text!r}")
+        for candidate in result.candidates[:top_k]:
+            print(f"  docid={candidate.docid} score={candidate.score:.4f}")
+
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Listwise minimax-m2 reranking through the OpenRouter API."
+    )
+    parser.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with prebuilt index (default: dl19).",
+    )
+    parser.add_argument(
+        "--model",
+        default="minimax/minimax-m2:free",
+        help="OpenRouter model id (default: minimax/minimax-m2:free).",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    parser.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    parser.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size for the model (default: 4096).",
+    )
+    parser.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    parser.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    parser.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    parser.add_argument(
+        "--base-url",
+        default="https://openrouter.ai/api/v1/",
+        help="OpenAI-compatible OpenRouter base URL.",
+    )
+    parser.add_argument(
+        "--prompt-template-path",
+        default=None,
+        help=(
+            "Path to a custom prompt-template YAML file. Defaults to the packaged "
+            "RankZephyr template."
+        ),
+    )
+    parser.add_argument(
+        "--reasoning-effort",
+        default=None,
+        help="Optional reasoning effort passed to models that support it.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    parser.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    args = parser.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    prompt_template_path = args.prompt_template_path
+
+    TEMPLATES = files("rank_llm.rerank.prompt_templates")
+    if prompt_template_path is None:
+        prompt_template_path = TEMPLATES / "rank_zephyr_template.yaml"
+
+    coordinator = SafeOpenai(
+        model=args.model,
+        context_size=args.context_size,
+        prompt_template_path=prompt_template_path,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        keys=get_openrouter_api_key(),
+        base_url=args.base_url,
+        api_type="openai",
+        reasoning_effort=args.reasoning_effort,
+        max_passage_words=args.max_passage_words,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
+    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    _print_sample(rerank_results)
+
+    analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=False)
+    error_counts = analyzer.count_errors()
+    print(error_counts.__repr__())
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
+
+    model_tag = args.model.split("/")[-1].replace(":", "-").lower()
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_openrouter.py
+++ b/src/rank_llm/demo/rerank_openrouter.py
@@ -153,7 +153,6 @@ def main() -> None:
         batch_size=args.batch_size,
         keys=get_openrouter_api_key(),
         base_url=args.base_url,
-        api_type="openai",
         reasoning_effort=args.reasoning_effort,
         max_passage_words=args.max_passage_words,
     )

--- a/src/rank_llm/demo/rerank_oss_bright.py
+++ b/src/rank_llm/demo/rerank_oss_bright.py
@@ -1,26 +1,13 @@
-import json
-import os
-import sys
-from importlib.resources import files
-from pathlib import Path
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-parent = os.path.dirname(SCRIPT_DIR)
-parent = os.path.dirname(parent)
-sys.path.append(parent)
-
-from rank_llm.data import DataWriter, read_requests_from_file
-from rank_llm.evaluation.trec_eval import EvalFunction
-from rank_llm.rerank import Reranker
-from rank_llm.rerank.listwise import RankListwiseOSLLM
-
 """
-Note: You need to run the vllm server with the following command:
+BRIGHT reranking demo using an OpenAI-compatible vLLM server running gpt-oss.
+
+Start the default model server before running this script:
+
 ```bash
 RANK_MODEL_ID="openai/gpt-oss-20b"
 RANK_PORT=48003
 RANK_VLLM_LOG="vllm_server_48003.log"
-CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID"  \
+CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID" \
  --port "$RANK_PORT" \
  --dtype auto \
  --gpu-memory-utilization 0.9 \
@@ -30,53 +17,288 @@ CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID"  \
  > "$RANK_VLLM_LOG" 2>&1 &
 ```
 """
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
-for fusion in ["bm25-splade", "bge-splade", "bm25-bge"]:
-    for task in [
-        "aops",
-        "biology",
-        "earth-science",
-        "economics",
-        "leetcode",
-        "pony",
-        "psychology",
-        "robotics",
-        "stackoverflow",
-        "sustainable-living",
-        "theoremqa-questions",
-        "theoremqa-theorems",
-    ]:
-        file_name = f"../bright_fusion/retrieve_results/retrieve_results_bright-{task}-rrf-{fusion}_top100.jsonl"
-        retrieve_results = read_requests_from_file(file_name)
-        qrels = f"../bright_fusion/qrels/qrels.bright-{task}.txt"
-        retrieve_ndcg_10 = EvalFunction.from_results(retrieve_results, qrels)
-        reranker = Reranker(
-            RankListwiseOSLLM(
-                context_size=4096 * 4,
-                model="openai/gpt-oss-20b",
-                use_alpha=True,
-                is_thinking=True,
-                reasoning_token_budget=4096 * 4,
-                base_url="http://localhost:48003/v1",
-                prompt_template_path=(TEMPLATES / "rank_zephyr_template.yaml"),
-            )
+
+import argparse
+import json
+import os
+import sys
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
+
+from rank_llm.analysis.response_analysis import ResponseAnalyzer
+from rank_llm.data import DataWriter, Result, read_requests_from_file
+from rank_llm.evaluation.trec_eval import EvalFunction
+from rank_llm.rerank import Reranker
+from rank_llm.rerank.listwise import RankListwiseOSLLM
+
+BRIGHT_DATASETS = (
+    "aops",
+    "biology",
+    "earth-science",
+    "economics",
+    "leetcode",
+    "pony",
+    "psychology",
+    "robotics",
+    "stackoverflow",
+    "sustainable-living",
+    "theoremqa-questions",
+    "theoremqa-theorems",
+)
+
+FUSIONS = (
+    "bm25-splade",
+    "bge-splade",
+    "bm25-bge",
+)
+
+NDCG_10_ARGS = ["-c", "-m", "ndcg_cut.10"]
+
+
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def load_sampling_kw_dict(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    Prefer --sampling-json-file > --sampling-json > SAMPLING_JSON env.
+    Returns {} when nothing is configured (RankLLM then omits extras).
+    """
+    if getattr(args, "sampling_json_file", None):
+        raw = Path(args.sampling_json_file).read_text(encoding="utf-8")
+        blob = json.loads(raw)
+    elif getattr(args, "sampling_json", None) not in (None, ""):
+        blob = json.loads(args.sampling_json)
+    else:
+        env_raw = os.environ.get("SAMPLING_JSON") or ""
+        if not env_raw.strip():
+            return {}
+        blob = json.loads(env_raw)
+    if not isinstance(blob, dict):
+        raise SystemExit("--sampling-json(|-file): root JSON must be an object.")
+    return blob
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise gpt-oss reranking of stored BRIGHT fusion results."
+    )
+    p.add_argument(
+        "--dataset",
+        choices=BRIGHT_DATASETS,
+        default="aops",
+        help="BRIGHT dataset category to rerank (default: aops).",
+    )
+    p.add_argument(
+        "--model",
+        default="openai/gpt-oss-20b",
+        help="Model id served by vLLM (default: openai/gpt-oss-20b).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k stored fusion results to load and rerank (default: 100).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help=(
+            "Output directory. When set, outputs go to "
+            "{output_dir}/{model_tag}/{dataset}/{fusion}/."
+        ),
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=16384,
+        help="Context size for the model (default: 16384).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    p.add_argument(
+        "--sampling-json",
+        default=None,
+        help="Inference sampling knobs as an inline JSON object string.",
+    )
+    p.add_argument(
+        "--sampling-json-file",
+        default=None,
+        help="JSON object file of inference sampling knobs.",
+    )
+    p.add_argument(
+        "--thinking",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable thinking mode (--thinking / --no-thinking; default: enabled).",
+    )
+    p.add_argument(
+        "--thinking-budget",
+        type=int,
+        default=16384,
+        help="Max reasoning tokens when --thinking is enabled (default: 16384).",
+    )
+    p.add_argument(
+        "--fusion",
+        choices=FUSIONS,
+        default="bm25-splade",
+        help="Stored first-stage fusion method (default: bm25-splade).",
+    )
+    p.add_argument(
+        "--bright-dir",
+        default="../bright_fusion",
+        help="Directory containing BRIGHT retrieve_results and qrels subdirectories.",
+    )
+    p.add_argument(
+        "--base-url",
+        default="http://localhost:48003/v1",
+        help="Base URL of the OpenAI-compatible vLLM server.",
+    )
+    p.add_argument(
+        "--prompt-template-path",
+        default=None,
+        help=(
+            "Path to a custom prompt-template YAML file. Defaults to the packaged "
+            "RankZephyr template."
+        ),
+    )
+    p.add_argument(
+        "--use-alpha",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use alphabetic passage identifiers (--use-alpha / --no-use-alpha; default: enabled).",
+    )
+    args = p.parse_args()
+
+    bright_dir = Path(args.bright_dir)
+    file_name = (
+        bright_dir
+        / "retrieve_results"
+        / f"retrieve_results_bright-{args.dataset}-rrf-{args.fusion}_top{args.k}.jsonl"
+    )
+    retrieve_results = read_requests_from_file(str(file_name))
+    if args.num_queries is not None:
+        retrieve_results = retrieve_results[: args.num_queries]
+    print(
+        f"Loaded {len(retrieve_results)} requests from BRIGHT {args.dataset} "
+        f"({args.fusion}, k={args.k})."
+    )
+
+    qrels = bright_dir / "qrels" / f"qrels.bright-{args.dataset}.txt"
+    run_eval = not args.skip_eval
+
+    retrieve_ndcg_10 = None
+    if run_eval:
+        retrieve_ndcg_10 = EvalFunction.from_results(
+            retrieve_results, str(qrels), NDCG_10_ARGS
         )
-        kwargs = {"populate_invocations_history": True}
-        rerank_results = reranker.rerank_batch(requests=retrieve_results, **kwargs)
-        rerank_ndcg_10 = EvalFunction.from_results(rerank_results, qrels)
-        writer = DataWriter(rerank_results)
-        path = Path("../bright_fusion/rerank_results/gpt-oss-20b")
-        path.mkdir(parents=True, exist_ok=True)
-        writer.write_in_jsonl_format(
-            os.path.join(path, f"{task}-rrf-{fusion}_top100.jsonl")
+        print(f"Retrieval nDCG@10: {retrieve_ndcg_10}")
+
+    TEMPLATES = files("rank_llm.rerank.prompt_templates")
+    prompt_template_path = args.prompt_template_path
+    if prompt_template_path is None:
+        prompt_template_path = TEMPLATES / "rank_zephyr_template.yaml"
+
+    coordinator = RankListwiseOSLLM(
+        model=args.model,
+        context_size=args.context_size,
+        prompt_template_path=prompt_template_path,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        max_passage_words=args.max_passage_words,
+        is_thinking=args.thinking,
+        reasoning_token_budget=args.thinking_budget,
+        sampling_kwargs=load_sampling_kw_dict(args) or None,
+        use_alpha=args.use_alpha,
+        base_url=args.base_url,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
+    rerank_results = reranker.rerank_batch(retrieve_results, **kwargs)
+    _print_sample(rerank_results)
+
+    analyzer = ResponseAnalyzer.from_inline_results(
+        rerank_results, use_alpha=args.use_alpha
+    )
+    error_counts = analyzer.count_errors()
+    print(error_counts.__repr__())
+
+    rerank_ndcg_10 = None
+    if run_eval:
+        rerank_ndcg_10 = EvalFunction.from_results(
+            rerank_results, str(qrels), NDCG_10_ARGS
         )
-        writer.write_in_trec_eval_format(
-            os.path.join(path, f"{task}-rrf-{fusion}_top100.txt")
-        )
-        writer.write_inference_invocations_history(
-            os.path.join(path, f"{task}-rrf-{fusion}_top100_invocations.json")
-        )
-        with open(
-            os.path.join(path, f"{task}-rrf-{fusion}_top100_metrics.json"), "w"
-        ) as f:
+        print(f"Reranking nDCG@10 ({args.model}): {rerank_ndcg_10}")
+
+    model_tag = args.model.split("/")[-1].lower()
+    if args.thinking:
+        model_tag += "-thinking"
+    else:
+        model_tag += "-non-thinking"
+
+    if args.output_dir:
+        output_root = Path(args.output_dir)
+    else:
+        output_root = bright_dir / "rerank_results"
+    out_path = output_root / model_tag / args.dataset / args.fusion
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+    if run_eval:
+        with (out_path / "metrics.json").open("w", encoding="utf-8") as f:
             json.dump({"retrieve": retrieve_ndcg_10, "rerank": rerank_ndcg_10}, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rank_llm/demo/rerank_oss_bright_async.py
+++ b/src/rank_llm/demo/rerank_oss_bright_async.py
@@ -1,20 +1,16 @@
 """
 BRIGHT reranking demo using OpenAI-compatible vLLM (gpt-oss-20b) with **async** API.
 
-Same inputs and outputs as ``rerank_oss_bright.py``, but each topic's requests are
-reranked with ``await reranker.rerank_async(...)`` per request (via ``asyncio.gather``),
-not ``rerank_batch``. That overlaps HTTP calls to the vLLM server while respecting the
-listwise per-instance concurrency cap.
+Same inputs and outputs as ``rerank_oss_bright.py``, but requests are reranked
+concurrently with ``await reranker.rerank_async(...)``.
 
-Requires the same vLLM server as ``rerank_oss_bright.py`` (see note below). Build the
-``Reranker`` **before** ``asyncio.run`` so tokenizer / client init stays off the async loop.
+Start the default model server before running this script:
 
-Note: You need to run the vllm server with the following command:
 ```bash
 RANK_MODEL_ID="openai/gpt-oss-20b"
 RANK_PORT=48003
 RANK_VLLM_LOG="vllm_server_48003.log"
-CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID"  \
+CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID" \
  --port "$RANK_PORT" \
  --dtype auto \
  --gpu-memory-utilization 0.9 \
@@ -25,101 +21,305 @@ CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID"  \
 ```
 """
 
+import argparse
 import asyncio
 import json
 import os
 import sys
 from importlib.resources import files
 from pathlib import Path
+from typing import Any
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
+from rank_llm.analysis.response_analysis import ResponseAnalyzer
 from rank_llm.data import DataWriter, Request, Result, read_requests_from_file
 from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker
 from rank_llm.rerank.listwise import RankListwiseOSLLM
 
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
+BRIGHT_DATASETS = (
+    "aops",
+    "biology",
+    "earth-science",
+    "economics",
+    "leetcode",
+    "pony",
+    "psychology",
+    "robotics",
+    "stackoverflow",
+    "sustainable-living",
+    "theoremqa-questions",
+    "theoremqa-theorems",
+)
+
+FUSIONS = (
+    "bm25-splade",
+    "bge-splade",
+    "bm25-bge",
+)
+
+NDCG_10_ARGS = ["-c", "-m", "ndcg_cut.10"]
 
 
-def build_reranker() -> Reranker:
-    return Reranker(
-        RankListwiseOSLLM(
-            context_size=4096 * 4,
-            model="openai/gpt-oss-20b",
-            use_alpha=True,
-            is_thinking=True,
-            reasoning_token_budget=4096 * 4,
-            base_url="http://localhost:48003/v1",
-            prompt_template_path=(TEMPLATES / "rank_zephyr_template.yaml"),
-        )
-    )
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def load_sampling_kw_dict(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    Prefer --sampling-json-file > --sampling-json > SAMPLING_JSON env.
+    Returns {} when nothing is configured (RankLLM then omits extras).
+    """
+    if getattr(args, "sampling_json_file", None):
+        raw = Path(args.sampling_json_file).read_text(encoding="utf-8")
+        blob = json.loads(raw)
+    elif getattr(args, "sampling_json", None) not in (None, ""):
+        blob = json.loads(args.sampling_json)
+    else:
+        env_raw = os.environ.get("SAMPLING_JSON") or ""
+        if not env_raw.strip():
+            return {}
+        blob = json.loads(env_raw)
+    if not isinstance(blob, dict):
+        raise SystemExit("--sampling-json(|-file): root JSON must be an object.")
+    return blob
 
 
 async def rerank_requests_async(
     reranker: Reranker,
     requests: list[Request],
-    **kwargs,
+    **kwargs: Any,
 ) -> list[Result]:
-    """One ``rerank_async`` per request; all share one event loop and reranker instance."""
-    return await asyncio.gather(
-        *(reranker.rerank_async(req, **kwargs) for req in requests)
+    """Rerank all requests concurrently on one event loop and reranker instance."""
+    return list(
+        await asyncio.gather(
+            *(reranker.rerank_async(request, **kwargs) for request in requests)
+        )
     )
 
 
-async def async_main(reranker: Reranker) -> None:
-    """One event loop for the whole run so the shared listwise semaphore stays valid."""
-    kwargs = {"populate_invocations_history": True}
-
-    for fusion in ["bm25-splade", "bge-splade", "bm25-bge"]:
-        for task in [
-            "aops",
-            "biology",
-            "earth-science",
-            "economics",
-            "leetcode",
-            "pony",
-            "psychology",
-            "robotics",
-            "stackoverflow",
-            "sustainable-living",
-            "theoremqa-questions",
-            "theoremqa-theorems",
-        ]:
-            file_name = f"../bright_fusion/retrieve_results/retrieve_results_bright-{task}-rrf-{fusion}_top100.jsonl"
-            retrieve_results = read_requests_from_file(file_name)
-            qrels = f"../bright_fusion/qrels/qrels.bright-{task}.txt"
-            retrieve_ndcg_10 = EvalFunction.from_results(retrieve_results, qrels)
-
-            rerank_results = await rerank_requests_async(
-                reranker, retrieve_results, **kwargs
-            )
-
-            rerank_ndcg_10 = EvalFunction.from_results(rerank_results, qrels)
-            writer = DataWriter(rerank_results)
-            path = Path("../bright_fusion/rerank_results/gpt-oss-20b-async")
-            path.mkdir(parents=True, exist_ok=True)
-            writer.write_in_jsonl_format(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100.jsonl")
-            )
-            writer.write_in_trec_eval_format(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100.txt")
-            )
-            writer.write_inference_invocations_history(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100_invocations.json")
-            )
-            with open(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100_metrics.json"), "w"
-            ) as f:
-                json.dump({"retrieve": retrieve_ndcg_10, "rerank": rerank_ndcg_10}, f)
-
-
 def main() -> None:
-    reranker = build_reranker()
-    asyncio.run(async_main(reranker))
+    p = argparse.ArgumentParser(
+        description="Async listwise gpt-oss reranking of stored BRIGHT fusion results."
+    )
+    p.add_argument(
+        "--dataset",
+        choices=BRIGHT_DATASETS,
+        default="aops",
+        help="BRIGHT dataset category to rerank (default: aops).",
+    )
+    p.add_argument(
+        "--model",
+        default="openai/gpt-oss-20b",
+        help="Model id served by vLLM (default: openai/gpt-oss-20b).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k stored fusion results to load and rerank (default: 100).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help=(
+            "Output directory. When set, outputs go to "
+            "{output_dir}/{model_tag}/{dataset}/{fusion}/."
+        ),
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=16384,
+        help="Context size for the model (default: 16384).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    p.add_argument(
+        "--sampling-json",
+        default=None,
+        help="Inference sampling knobs as an inline JSON object string.",
+    )
+    p.add_argument(
+        "--sampling-json-file",
+        default=None,
+        help="JSON object file of inference sampling knobs.",
+    )
+    p.add_argument(
+        "--thinking",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable thinking mode (--thinking / --no-thinking; default: enabled).",
+    )
+    p.add_argument(
+        "--thinking-budget",
+        type=int,
+        default=16384,
+        help="Max reasoning tokens when --thinking is enabled (default: 16384).",
+    )
+    p.add_argument(
+        "--fusion",
+        choices=FUSIONS,
+        default="bm25-splade",
+        help="Stored first-stage fusion method (default: bm25-splade).",
+    )
+    p.add_argument(
+        "--bright-dir",
+        default="../bright_fusion",
+        help="Directory containing BRIGHT retrieve_results and qrels subdirectories.",
+    )
+    p.add_argument(
+        "--base-url",
+        default="http://localhost:48003/v1",
+        help="Base URL of the OpenAI-compatible vLLM server.",
+    )
+    p.add_argument(
+        "--prompt-template-path",
+        default=None,
+        help=(
+            "Path to a custom prompt-template YAML file. Defaults to the packaged "
+            "RankZephyr template."
+        ),
+    )
+    p.add_argument(
+        "--use-alpha",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use alphabetic passage identifiers (--use-alpha / --no-use-alpha; default: enabled).",
+    )
+    args = p.parse_args()
+
+    bright_dir = Path(args.bright_dir)
+    file_name = (
+        bright_dir
+        / "retrieve_results"
+        / f"retrieve_results_bright-{args.dataset}-rrf-{args.fusion}_top{args.k}.jsonl"
+    )
+    retrieve_results = read_requests_from_file(str(file_name))
+    if args.num_queries is not None:
+        retrieve_results = retrieve_results[: args.num_queries]
+    print(
+        f"Loaded {len(retrieve_results)} requests from BRIGHT {args.dataset} "
+        f"({args.fusion}, k={args.k})."
+    )
+
+    qrels = bright_dir / "qrels" / f"qrels.bright-{args.dataset}.txt"
+    run_eval = not args.skip_eval
+
+    retrieve_ndcg_10 = None
+    if run_eval:
+        retrieve_ndcg_10 = EvalFunction.from_results(
+            retrieve_results, str(qrels), NDCG_10_ARGS
+        )
+        print(f"Retrieval nDCG@10: {retrieve_ndcg_10}")
+
+    TEMPLATES = files("rank_llm.rerank.prompt_templates")
+    prompt_template_path = args.prompt_template_path
+    if prompt_template_path is None:
+        prompt_template_path = TEMPLATES / "rank_zephyr_template.yaml"
+
+    coordinator = RankListwiseOSLLM(
+        model=args.model,
+        context_size=args.context_size,
+        prompt_template_path=prompt_template_path,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        max_passage_words=args.max_passage_words,
+        is_thinking=args.thinking,
+        reasoning_token_budget=args.thinking_budget,
+        sampling_kwargs=load_sampling_kw_dict(args) or None,
+        use_alpha=args.use_alpha,
+        base_url=args.base_url,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
+
+    print(f"Reranking {len(retrieve_results)} requests concurrently.")
+    rerank_results = asyncio.run(
+        rerank_requests_async(reranker, retrieve_results, **kwargs)
+    )
+    _print_sample(rerank_results)
+
+    analyzer = ResponseAnalyzer.from_inline_results(
+        rerank_results, use_alpha=args.use_alpha
+    )
+    error_counts = analyzer.count_errors()
+    print(error_counts.__repr__())
+
+    rerank_ndcg_10 = None
+    if run_eval:
+        rerank_ndcg_10 = EvalFunction.from_results(
+            rerank_results, str(qrels), NDCG_10_ARGS
+        )
+        print(f"Reranking nDCG@10 ({args.model}): {rerank_ndcg_10}")
+
+    model_tag = args.model.split("/")[-1].lower()
+    if args.thinking:
+        model_tag += "-thinking"
+    else:
+        model_tag += "-non-thinking"
+    model_tag += "-async"
+
+    if args.output_dir:
+        output_root = Path(args.output_dir)
+    else:
+        output_root = bright_dir / "rerank_results"
+    out_path = output_root / model_tag / args.dataset / args.fusion
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+    if run_eval:
+        with (out_path / "metrics.json").open("w", encoding="utf-8") as f:
+            json.dump({"retrieve": retrieve_ndcg_10, "rerank": rerank_ndcg_10}, f)
 
 
 if __name__ == "__main__":

--- a/src/rank_llm/demo/rerank_qwen-r1-distill.py
+++ b/src/rank_llm/demo/rerank_qwen-r1-distill.py
@@ -1,7 +1,10 @@
+import argparse
+import json
 import os
 import sys
 from importlib.resources import files
 from pathlib import Path
+from typing import Any
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 parent = os.path.dirname(SCRIPT_DIR)
@@ -18,47 +21,225 @@ except RuntimeError:
     pass  # already set, fine
 
 from rank_llm.analysis.response_analysis import ResponseAnalyzer
-from rank_llm.data import DataWriter
+from rank_llm.data import DataWriter, Result
 from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker
 from rank_llm.rerank.listwise import RankListwiseOSLLM
-from rank_llm.retrieve import Retriever
-from rank_llm.retrieve.topics_dict import TOPICS
+from rank_llm.retrieve import TOPICS, Retriever
+
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
+
+
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def load_sampling_kw_dict(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    Prefer --sampling-json-file > --sampling-json > SAMPLING_JSON env.
+    Returns {} when nothing is configured (RankLLM then omits extras).
+    """
+    if getattr(args, "sampling_json_file", None):
+        raw = Path(args.sampling_json_file).read_text(encoding="utf-8")
+        blob = json.loads(raw)
+    elif getattr(args, "sampling_json", None) not in (None, ""):
+        blob = json.loads(args.sampling_json)
+    else:
+        env_raw = os.environ.get("SAMPLING_JSON") or ""
+        if not env_raw.strip():
+            return {}
+        blob = json.loads(env_raw)
+    if not isinstance(blob, dict):
+        raise SystemExit("--sampling-json(|-file): root JSON must be an object.")
+    return blob
 
 
 def main():
-    # By default uses BM25 for retrieval
-    dataset_name = "dl19"
-    requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
-    TEMPLATES = files("rank_llm.rerank.prompt_templates")
-    model_coordinator = RankListwiseOSLLM(
-        model="deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
-        is_thinking=True,
-        reasoning_token_budget=30000,
-        prompt_template_path=(TEMPLATES / "qwen_thinking_template.yaml"),
+    p = argparse.ArgumentParser(
+        description="Listwise DeepSeek-R1 Qwen3 distill reranking demo."
     )
-    reranker = Reranker(model_coordinator)
-    kwargs = {"populate_invocations_history": True}
-    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with prebuilt index (default: dl19).",
+    )
+    p.add_argument(
+        "--model",
+        default="deepseek-ai/DeepSeek-R1-0528-Qwen3-8B",
+        help="HuggingFace model id (default: deepseek-ai/DeepSeek-R1-0528-Qwen3-8B).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size for the model (default: 4096).",
+    )
+    p.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--num-gpus",
+        type=int,
+        default=1,
+        help="Number of GPUs for tensor parallelism (default: 1).",
+    )
+    p.add_argument(
+        "--thinking",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable thinking mode for reasoning models (--thinking / --no-thinking; default: enabled).",
+    )
+    p.add_argument(
+        "--thinking-budget",
+        type=int,
+        default=30000,
+        help="Max reasoning tokens when --thinking is enabled (default: 30000).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    p.add_argument(
+        "--sampling-json-file",
+        default=None,
+        help=(
+            "JSON object file of inference sampling knobs (temperature, "
+            "top_k, repetition_penalty, presence_penalty, frequency_penalty, "
+            "stop, ...)."
+        ),
+    )
+    p.add_argument(
+        "--sampling-json",
+        default=None,
+        help="Same fields as sampling-json-file, as an inline JSON object string.",
+    )
+    p.add_argument(
+        "--prompt-template-path",
+        default=None,
+        help=(
+            "Path to a custom prompt-template YAML file. Defaults to the packaged "
+            "Qwen thinking template when thinking is enabled."
+        ),
+    )
+    args = p.parse_args()
 
-    # Analyze the response
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    TEMPLATES = files("rank_llm.rerank.prompt_templates")
+    prompt_template_path = args.prompt_template_path
+
+    if prompt_template_path is None and args.thinking:
+        prompt_template_path = TEMPLATES / "qwen_thinking_template.yaml"
+
+    coordinator = RankListwiseOSLLM(
+        model=args.model,
+        context_size=args.context_size,
+        prompt_template_path=prompt_template_path,
+        num_gpus=args.num_gpus,
+        window_size=args.window_size,
+        stride=args.stride,
+        is_thinking=args.thinking,
+        reasoning_token_budget=args.thinking_budget,
+        sampling_kwargs=load_sampling_kw_dict(args) or None,
+        batch_size=args.batch_size,
+        max_passage_words=args.max_passage_words,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
+    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    _print_sample(rerank_results)
+
     analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=False)
     error_counts = analyzer.count_errors()
     print(error_counts.__repr__())
 
-    # Eval
-    topics = TOPICS[dataset_name]
-    rerank_ndcg_10 = EvalFunction.from_results(rerank_results, topics)
-    print(rerank_ndcg_10)
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
 
-    # Write rerank results
+    model_tag = args.model.split("/")[-1].lower()
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
+
     writer = DataWriter(rerank_results)
-    Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-    writer.write_in_jsonl_format("demo_outputs/rerank_results_qwen-r1-distill.jsonl")
-    writer.write_in_trec_eval_format("demo_outputs/rerank_results_qwen-r1-distill.txt")
-    writer.write_inference_invocations_history(
-        "demo_outputs/inference_invocations_history_qwen-r1-distill.json"
-    )
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
 
 
 if __name__ == "__main__":

--- a/src/rank_llm/demo/rerank_qwen.py
+++ b/src/rank_llm/demo/rerank_qwen.py
@@ -24,8 +24,7 @@ from rank_llm.data import DataWriter, Result
 from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker
 from rank_llm.rerank.listwise import RankListwiseOSLLM
-from rank_llm.retrieve.retriever import Retriever
-from rank_llm.retrieve.topics_dict import TOPICS
+from rank_llm.retrieve import TOPICS, Retriever
 
 EVAL_METRICS: list[tuple[str, list[str]]] = [
     ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),

--- a/src/rank_llm/demo/rerank_qwen.py
+++ b/src/rank_llm/demo/rerank_qwen.py
@@ -1,6 +1,9 @@
+import argparse
+import json
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 parent = os.path.dirname(SCRIPT_DIR)
@@ -17,47 +20,199 @@ except RuntimeError:
     pass  # already set, fine
 
 from rank_llm.analysis.response_analysis import ResponseAnalyzer
-from rank_llm.data import DataWriter
+from rank_llm.data import DataWriter, Result
 from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker
 from rank_llm.rerank.listwise import RankListwiseOSLLM
-from rank_llm.retrieve import Retriever
+from rank_llm.retrieve.retriever import Retriever
 from rank_llm.retrieve.topics_dict import TOPICS
+
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
+
+
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def load_sampling_kw_dict(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    Prefer --sampling-json-file > --sampling-json > SAMPLING_JSON env.
+    Returns {} when nothing is configured (RankLLM then omits extras).
+    """
+    if getattr(args, "sampling_json_file", None):
+        raw = Path(args.sampling_json_file).read_text(encoding="utf-8")
+        blob = json.loads(raw)
+    elif getattr(args, "sampling_json", None) not in (None, ""):
+        blob = json.loads(args.sampling_json)
+    else:
+        env_raw = os.environ.get("SAMPLING_JSON") or ""
+        if not env_raw.strip():
+            return {}
+        blob = json.loads(env_raw)
+    if not isinstance(blob, dict):
+        raise SystemExit("--sampling-json(|-file): root JSON must be an object.")
+    return blob
 
 
 def main():
-    # By default uses BM25 for retrieval
-    dataset_name = "dl19"
-    requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
-    model_coordinator = RankListwiseOSLLM(
-        model="Qwen/Qwen2.5-7B-Instruct",
+    p = argparse.ArgumentParser(description="Listwise Qwen2.5-7B reranking demo.")
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with prebuilt index (default: dl19).",
     )
-    reranker = Reranker(model_coordinator)
-    kwargs = {"populate_invocations_history": True}
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--model",
+        default="Qwen/Qwen2.5-7B-Instruct",
+        help="HuggingFace model id (default: Qwen/Qwen2.5-7B-Instruct).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size for the model (default: 4096).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride", type=int, default=10, help="Sliding-window stride (default: 10)."
+    )
+    p.add_argument(
+        "--num-gpus",
+        type=int,
+        default=1,
+        help="Number of GPUs for tensor parallelism (default: 1).",
+    )
+    p.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    p.add_argument(
+        "--sampling-json-file",
+        default=None,
+        help=(
+            "JSON object file of inference sampling knobs (temperature, "
+            "top_k, repetition_penalty, presence_penalty, frequency_penalty, "
+            "stop, ...)."
+        ),
+    )
+    p.add_argument(
+        "--sampling-json",
+        default=None,
+        help="Same fields as sampling-json-file, as an inline JSON object string.",
+    )
+
+    args = p.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    # Eval
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    # Pre Reranking Eval
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    coordinator = RankListwiseOSLLM(
+        model=args.model,
+        context_size=args.context_size,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        num_gpus=args.num_gpus,
+        max_passage_words=args.max_passage_words,
+        sampling_kwargs=load_sampling_kw_dict(args) or None,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
     rerank_results = reranker.rerank_batch(requests, **kwargs)
+    _print_sample(rerank_results)
 
     # Analyze the response
     analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=False)
     error_counts = analyzer.count_errors()
     print(error_counts.__repr__())
 
-    # Eval
-    topics = TOPICS[dataset_name]
-    rerank_ndcg_10 = EvalFunction.from_results(rerank_results, topics)
-    print(rerank_ndcg_10)
+    # Post Reranking Eval
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
+
+    model_tag = args.model.split("/")[-1].lower()
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+
+    out_path.mkdir(parents=True, exist_ok=True)
 
     # Write rerank results
     writer = DataWriter(rerank_results)
-    Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-    writer.write_in_jsonl_format(
-        "demo_outputs/rerank_results_qwen2.5-7b-instruct.jsonl"
-    )
-    writer.write_in_trec_eval_format(
-        "demo_outputs/rerank_results_qwen2.5-7b-instruct.txt"
-    )
-    writer.write_inference_invocations_history(
-        "demo_outputs/inference_invocations_history_qwen2.5-7b-instruct.json"
-    )
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
 
 
 if __name__ == "__main__":

--- a/src/rank_llm/demo/rerank_qwen3_bright.py
+++ b/src/rank_llm/demo/rerank_qwen3_bright.py
@@ -1,36 +1,13 @@
-import os
-import sys
-from pathlib import Path
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-parent = os.path.dirname(os.path.dirname(SCRIPT_DIR))
-sys.path.append(parent)
-
-# --- set spawn before importing libs that might touch CUDA/vLLM ---
-os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
-import multiprocessing as mp
-
-try:
-    mp.set_start_method("spawn")
-except RuntimeError:
-    pass  # already set, fine
-
-# now safe to import the rest
-
-import json
-
-from rank_llm.data import DataWriter, read_requests_from_file
-from rank_llm.evaluation.trec_eval import EvalFunction
-from rank_llm.rerank import Reranker
-from rank_llm.rerank.listwise import RankListwiseOSLLM
-
 """
-Note: You need to run the vllm server with the following command:
+BRIGHT reranking demo using an OpenAI-compatible vLLM server running Qwen3.
+
+Start the default model server before running this script:
+
 ```bash
 RANK_MODEL_ID="Qwen/Qwen3-8B"
 RANK_PORT=38003
-RANK_VLLM_LOG="vllm_server_48003.log"
-CUDA_VISIBLE_DEVICES=2 vllm serve "$RANK_MODEL_ID"  \
+RANK_VLLM_LOG="vllm_server_38003.log"
+CUDA_VISIBLE_DEVICES=0 vllm serve "$RANK_MODEL_ID" \
  --port "$RANK_PORT" \
  --dtype auto \
  --gpu-memory-utilization 0.9 \
@@ -42,58 +19,289 @@ CUDA_VISIBLE_DEVICES=2 vllm serve "$RANK_MODEL_ID"  \
 ```
 """
 
+import argparse
+import json
+import os
+import sys
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
 
-def main():
-    for fusion in ["bge-splade", "bm25-bge", "bm25-splade"]:
-        for task in [
-            "aops",
-            "biology",
-            "earth-science",
-            "economics",
-            "leetcode",
-            "pony",
-            "psychology",
-            "robotics",
-            "stackoverflow",
-            "sustainable-living",
-            "theoremqa-questions",
-            "theoremqa-theorems",
-        ]:
-            file_name = f"../bright_fusion/retrieve_results/retrieve_results_bright-{task}-rrf-{fusion}_top100.jsonl"
-            retrieve_results = read_requests_from_file(file_name)
-            qrels = f"../bright_fusion/qrels/qrels.bright-{task}.txt"
-            retrieve_ndcg_10 = EvalFunction.from_results(retrieve_results, qrels)
-            reranker = Reranker(
-                RankListwiseOSLLM(
-                    context_size=4096 * 4,
-                    model="Qwen/Qwen3-8B",
-                    use_alpha=True,
-                    is_thinking=True,
-                    reasoning_token_budget=4096 * 4,
-                    base_url="http://localhost:38003/v1",
-                )
-            )
-            kwargs = {"populate_invocations_history": True}
-            rerank_results = reranker.rerank_batch(requests=retrieve_results, **kwargs)
-            rerank_ndcg_10 = EvalFunction.from_results(rerank_results, qrels)
-            writer = DataWriter(rerank_results)
-            path = Path("../bright_fusion/rerank_results/Qwen3-8B")
-            path.mkdir(parents=True, exist_ok=True)
-            writer.write_in_jsonl_format(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100.jsonl")
-            )
-            writer.write_in_trec_eval_format(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100.txt")
-            )
-            writer.write_inference_invocations_history(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100_invocations.json")
-            )
-            with open(
-                os.path.join(path, f"{task}-rrf-{fusion}_top100_metrics.json"), "w"
-            ) as f:
-                json.dump({"retrieve": retrieve_ndcg_10, "rerank": rerank_ndcg_10}, f)
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+parent = os.path.dirname(SCRIPT_DIR)
+parent = os.path.dirname(parent)
+sys.path.append(parent)
 
-            del reranker  # optional: explicit cleanup if your class supports it
+from rank_llm.analysis.response_analysis import ResponseAnalyzer
+from rank_llm.data import DataWriter, Result, read_requests_from_file
+from rank_llm.evaluation.trec_eval import EvalFunction
+from rank_llm.rerank import Reranker
+from rank_llm.rerank.listwise import RankListwiseOSLLM
+
+BRIGHT_DATASETS = (
+    "aops",
+    "biology",
+    "earth-science",
+    "economics",
+    "leetcode",
+    "pony",
+    "psychology",
+    "robotics",
+    "stackoverflow",
+    "sustainable-living",
+    "theoremqa-questions",
+    "theoremqa-theorems",
+)
+
+FUSIONS = (
+    "bge-splade",
+    "bm25-bge",
+    "bm25-splade",
+)
+
+NDCG_10_ARGS = ["-c", "-m", "ndcg_cut.10"]
+
+
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def load_sampling_kw_dict(args: argparse.Namespace) -> dict[str, Any]:
+    """
+    Prefer --sampling-json-file > --sampling-json > SAMPLING_JSON env.
+    Returns {} when nothing is configured (RankLLM then omits extras).
+    """
+    if getattr(args, "sampling_json_file", None):
+        raw = Path(args.sampling_json_file).read_text(encoding="utf-8")
+        blob = json.loads(raw)
+    elif getattr(args, "sampling_json", None) not in (None, ""):
+        blob = json.loads(args.sampling_json)
+    else:
+        env_raw = os.environ.get("SAMPLING_JSON") or ""
+        if not env_raw.strip():
+            return {}
+        blob = json.loads(env_raw)
+    if not isinstance(blob, dict):
+        raise SystemExit("--sampling-json(|-file): root JSON must be an object.")
+    return blob
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise Qwen3 reranking of stored BRIGHT fusion results."
+    )
+    p.add_argument(
+        "--dataset",
+        choices=BRIGHT_DATASETS,
+        default="aops",
+        help="BRIGHT dataset category to rerank (default: aops).",
+    )
+    p.add_argument(
+        "--model",
+        default="Qwen/Qwen3-8B",
+        help="Model id served by vLLM (default: Qwen/Qwen3-8B).",
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k stored fusion results to load and rerank (default: 100).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help=(
+            "Output directory. When set, outputs go to "
+            "{output_dir}/{model_tag}/{dataset}/{fusion}/."
+        ),
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=16384,
+        help="Context size for the model (default: 16384).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    p.add_argument(
+        "--sampling-json",
+        default=None,
+        help="Inference sampling knobs as an inline JSON object string.",
+    )
+    p.add_argument(
+        "--sampling-json-file",
+        default=None,
+        help="JSON object file of inference sampling knobs.",
+    )
+    p.add_argument(
+        "--thinking",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable thinking mode (--thinking / --no-thinking; default: enabled).",
+    )
+    p.add_argument(
+        "--thinking-budget",
+        type=int,
+        default=16384,
+        help="Max reasoning tokens when --thinking is enabled (default: 16384).",
+    )
+    p.add_argument(
+        "--fusion",
+        choices=FUSIONS,
+        default="bge-splade",
+        help="Stored first-stage fusion method (default: bge-splade).",
+    )
+    p.add_argument(
+        "--bright-dir",
+        default="../bright_fusion",
+        help="Directory containing BRIGHT retrieve_results and qrels subdirectories.",
+    )
+    p.add_argument(
+        "--base-url",
+        default="http://localhost:38003/v1",
+        help="Base URL of the OpenAI-compatible vLLM server.",
+    )
+    p.add_argument(
+        "--prompt-template-path",
+        default=None,
+        help=(
+            "Path to a custom prompt-template YAML file. Defaults to the packaged "
+            "alphabetic RankZephyr template."
+        ),
+    )
+    p.add_argument(
+        "--use-alpha",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use alphabetic passage identifiers (--use-alpha / --no-use-alpha; default: enabled).",
+    )
+    args = p.parse_args()
+
+    bright_dir = Path(args.bright_dir)
+    file_name = (
+        bright_dir
+        / "retrieve_results"
+        / f"retrieve_results_bright-{args.dataset}-rrf-{args.fusion}_top{args.k}.jsonl"
+    )
+    retrieve_results = read_requests_from_file(str(file_name))
+    if args.num_queries is not None:
+        retrieve_results = retrieve_results[: args.num_queries]
+    print(
+        f"Loaded {len(retrieve_results)} requests from BRIGHT {args.dataset} "
+        f"({args.fusion}, k={args.k})."
+    )
+
+    qrels = bright_dir / "qrels" / f"qrels.bright-{args.dataset}.txt"
+    run_eval = not args.skip_eval
+
+    retrieve_ndcg_10 = None
+    if run_eval:
+        retrieve_ndcg_10 = EvalFunction.from_results(
+            retrieve_results, str(qrels), NDCG_10_ARGS
+        )
+        print(f"Retrieval nDCG@10: {retrieve_ndcg_10}")
+
+    TEMPLATES = files("rank_llm.rerank.prompt_templates")
+    prompt_template_path = args.prompt_template_path
+    if prompt_template_path is None:
+        if args.use_alpha:
+            prompt_template_path = TEMPLATES / "rank_zephyr_alpha_template.yaml"
+        else:
+            prompt_template_path = TEMPLATES / "rank_zephyr_template.yaml"
+
+    coordinator = RankListwiseOSLLM(
+        model=args.model,
+        context_size=args.context_size,
+        prompt_template_path=prompt_template_path,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
+        max_passage_words=args.max_passage_words,
+        is_thinking=args.thinking,
+        reasoning_token_budget=args.thinking_budget,
+        sampling_kwargs=load_sampling_kw_dict(args) or None,
+        use_alpha=args.use_alpha,
+        base_url=args.base_url,
+    )
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
+    rerank_results = reranker.rerank_batch(retrieve_results, **kwargs)
+    _print_sample(rerank_results)
+
+    analyzer = ResponseAnalyzer.from_inline_results(
+        rerank_results, use_alpha=args.use_alpha
+    )
+    error_counts = analyzer.count_errors()
+    print(error_counts.__repr__())
+
+    rerank_ndcg_10 = None
+    if run_eval:
+        rerank_ndcg_10 = EvalFunction.from_results(
+            rerank_results, str(qrels), NDCG_10_ARGS
+        )
+        print(f"Reranking nDCG@10 ({args.model}): {rerank_ndcg_10}")
+
+    model_tag = args.model.split("/")[-1].lower()
+    if args.thinking:
+        model_tag += "-thinking"
+    else:
+        model_tag += "-non-thinking"
+
+    if args.output_dir:
+        output_root = Path(args.output_dir)
+    else:
+        output_root = bright_dir / "rerank_results"
+    out_path = output_root / model_tag / args.dataset / args.fusion
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
+
+    if run_eval:
+        with (out_path / "metrics.json").open("w", encoding="utf-8") as f:
+            json.dump({"retrieve": retrieve_ndcg_10, "rerank": rerank_ndcg_10}, f)
 
 
 if __name__ == "__main__":

--- a/src/rank_llm/demo/rerank_qwen_openrouter.py
+++ b/src/rank_llm/demo/rerank_qwen_openrouter.py
@@ -3,6 +3,7 @@ Qwen-R1-Distill reranker using OpenRouter
 Based on OpenRouter integration in commit 55d5c1f4a49080e92af1b19a184ea57982ae9f8b
 """
 
+import argparse
 import os
 import sys
 from importlib.resources import files
@@ -13,82 +14,194 @@ parent = os.path.dirname(SCRIPT_DIR)
 parent = os.path.dirname(parent)
 sys.path.append(parent)
 
-from rank_llm.data import DataWriter
+from rank_llm.analysis.response_analysis import ResponseAnalyzer
+from rank_llm.data import DataWriter, Result
+from rank_llm.evaluation.trec_eval import EvalFunction
 from rank_llm.rerank import Reranker, get_openrouter_api_key
 from rank_llm.rerank.listwise import SafeOpenai
-from rank_llm.retrieve import Retriever
+from rank_llm.retrieve import TOPICS, Retriever
 
-# By default uses BM25 for retrieval
-dataset_name = "dl19"
-requests = Retriever.from_dataset_with_prebuilt_index(dataset_name)
-TEMPLATES = files("rank_llm.rerank.prompt_templates")
+EVAL_METRICS: list[tuple[str, list[str]]] = [
+    ("nDCG@10", ["-c", "-m", "ndcg_cut.10"]),
+    ("MAP@100", ["-c", "-m", "map_cut.100", "-l2"]),
+    ("Recall@20", ["-c", "-m", "recall.20"]),
+    ("Recall@100", ["-c", "-m", "recall.100"]),
+]
 
-model = "deepseek/deepseek-r1-distill-qwen-14b:free"
-print(f"Testing {len(requests)} queries")
 
-# Test with thinking mode
-try:
-    thinking_coordinator = SafeOpenai(
-        model,
-        4096,
+def _print_sample(results: list[Result], max_queries: int = 2, top_k: int = 5) -> None:
+    for res in results[:max_queries]:
+        print(f"qid={res.query.qid} text={res.query.text!r}")
+        for c in res.candidates[:top_k]:
+            print(f"  docid={c.docid} score={c.score:.4f}")
+
+
+def _print_eval(results: list[Result], qrels: str) -> None:
+    for label, eval_args in EVAL_METRICS:
+        value = EvalFunction.from_results(results, qrels, eval_args)
+        print(f"  {label:12s} {value}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Listwise Qwen-R1-Distill reranking through the OpenRouter API."
+    )
+    p.add_argument(
+        "--dataset",
+        default="dl19",
+        help="TREC dataset name with prebuilt index (default: dl19).",
+    )
+    p.add_argument(
+        "--model",
+        default="deepseek/deepseek-r1-distill-qwen-14b:free",
+        help=(
+            "OpenRouter model id (default: deepseek/deepseek-r1-distill-qwen-14b:free)."
+        ),
+    )
+    p.add_argument(
+        "--k",
+        type=int,
+        default=100,
+        help="Top-k passages per query from first-stage retrieval (default: 100).",
+    )
+    p.add_argument(
+        "--num-queries",
+        type=int,
+        default=None,
+        help="Cap the number of queries for a quick smoke test (default: all).",
+    )
+    p.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory. When set, outputs go to "
+        "{output_dir}/{model_tag}/{dataset}/.",
+    )
+    p.add_argument(
+        "--skip-eval",
+        action="store_true",
+        help="Skip inline evaluation (useful in batch benchmark runs).",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size used by the listwise inference handler (default: 32).",
+    )
+    p.add_argument(
+        "--context-size",
+        type=int,
+        default=4096,
+        help="Context size for the model (default: 4096).",
+    )
+    p.add_argument(
+        "--window-size",
+        type=int,
+        default=20,
+        help="Sliding-window size over candidates (default: 20).",
+    )
+    p.add_argument(
+        "--stride",
+        type=int,
+        default=10,
+        help="Sliding-window stride (default: 10).",
+    )
+    p.add_argument(
+        "--max-passage-words",
+        type=int,
+        default=300,
+        help="Per-passage word truncation limit (default: 300).",
+    )
+    p.add_argument(
+        "--thinking",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use the Qwen thinking prompt template (--thinking / --no-thinking; default: enabled).",
+    )
+    p.add_argument(
+        "--base-url",
+        default="https://openrouter.ai/api/v1/",
+        help="OpenAI-compatible OpenRouter base URL.",
+    )
+    p.add_argument(
+        "--prompt-template-path",
+        default=None,
+        help=(
+            "Path to a custom prompt-template YAML file. Defaults to the packaged "
+            "Qwen template for the selected thinking mode."
+        ),
+    )
+    args = p.parse_args()
+
+    requests = Retriever.from_dataset_with_prebuilt_index(args.dataset, k=args.k)
+    if args.num_queries is not None:
+        requests = requests[: args.num_queries]
+    print(f"Loaded {len(requests)} requests from {args.dataset} (k={args.k}).")
+
+    qrels = TOPICS.get(args.dataset)
+    run_eval = not args.skip_eval
+
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Retrieval metrics  (BM25, k={args.k})")
+        print(f"{'=' * 60}")
+        _print_eval(requests, qrels)
+
+    TEMPLATES = files("rank_llm.rerank.prompt_templates")
+    prompt_template_path = args.prompt_template_path
+
+    if prompt_template_path is None:
+        if args.thinking:
+            prompt_template_path = TEMPLATES / "qwen_thinking_template.yaml"
+        else:
+            prompt_template_path = TEMPLATES / "qwen_non_thinking_template.yaml"
+
+    coordinator = SafeOpenai(
+        model=args.model,
+        context_size=args.context_size,
+        prompt_template_path=prompt_template_path,
+        window_size=args.window_size,
+        stride=args.stride,
+        batch_size=args.batch_size,
         keys=get_openrouter_api_key(),
-        base_url="https://openrouter.ai/api/v1/",
-        prompt_template_path=(TEMPLATES / "qwen_thinking_template.yaml"),
+        base_url=args.base_url,
+        max_passage_words=args.max_passage_words,
     )
-    thinking_reranker = Reranker(thinking_coordinator)
-    print(f"Using {model} with thinking mode via OpenRouter")
+    reranker = Reranker(coordinator)
+    kwargs = {
+        "populate_invocations_history": True,
+        "top_k_retrieve": args.k,
+        "rank_end": args.k,
+    }
+    rerank_results = reranker.rerank_batch(requests, **kwargs)
+    _print_sample(rerank_results)
 
-    thinking_results = thinking_reranker.rerank_batch(
-        requests, populate_invocations_history=True
-    )
+    analyzer = ResponseAnalyzer.from_inline_results(rerank_results, use_alpha=False)
+    error_counts = analyzer.count_errors()
+    print(error_counts.__repr__())
 
-    # Save thinking results
-    writer = DataWriter(thinking_results)
-    Path("demo_outputs/").mkdir(parents=True, exist_ok=True)
-    writer.write_in_jsonl_format("demo_outputs/qwen_openrouter_thinking_results.jsonl")
-    writer.write_in_trec_eval_format(
-        "demo_outputs/qwen_openrouter_thinking_results.txt"
-    )
-    writer.write_inference_invocations_history(
-        "demo_outputs/qwen_openrouter_thinking_invocations.json"
-    )
+    if qrels and run_eval:
+        print(f"\n{'=' * 60}")
+        print(f"Reranking metrics  ({args.model})")
+        print(f"{'=' * 60}")
+        _print_eval(rerank_results, qrels)
 
-    print("Thinking mode results saved")
+    model_tag = args.model.split("/")[-1].replace(":", "-").lower()
+    if args.thinking:
+        model_tag += "-thinking"
+    else:
+        model_tag += "-non-thinking"
 
-except Exception as e:
-    print(f"Thinking mode failed: {e}")
+    if args.output_dir:
+        out_path = Path(args.output_dir) / model_tag / args.dataset
+    else:
+        out_path = Path("demo_outputs")
+    out_path.mkdir(parents=True, exist_ok=True)
 
-# Test without thinking
-try:
-    non_thinking_coordinator = SafeOpenai(
-        model,
-        4096,
-        keys=get_openrouter_api_key(),
-        base_url="https://openrouter.ai/api/v1/",
-        prompt_template_path=(TEMPLATES / "qwen_non_thinking_template.yaml"),
-    )
-    non_thinking_reranker = Reranker(non_thinking_coordinator)
-    print(f"Using {model} with non-thinking mode")
+    writer = DataWriter(rerank_results)
+    writer.write_in_jsonl_format(str(out_path / "rerank.jsonl"))
+    writer.write_in_trec_eval_format(str(out_path / "rerank.txt"))
+    writer.write_inference_invocations_history(str(out_path / "invocations.json"))
 
-    non_thinking_results = non_thinking_reranker.rerank_batch(
-        requests, populate_invocations_history=True
-    )
 
-    # Save non-thinking results
-    writer = DataWriter(non_thinking_results)
-    writer.write_in_jsonl_format(
-        "demo_outputs/qwen_openrouter_non_thinking_results.jsonl"
-    )
-    writer.write_in_trec_eval_format(
-        "demo_outputs/qwen_openrouter_non_thinking_results.txt"
-    )
-    writer.write_inference_invocations_history(
-        "demo_outputs/qwen_openrouter_non_thinking_invocations.json"
-    )
-
-    print("Non-thinking mode results saved")
-
-except Exception as e:
-    print(f"Non-thinking mode failed: {e}")
-
-print("Results saved to demo_outputs/")
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request Checklist

## Reference Issue

Please provide the reference to issue this PR is addressing (# followed by the issue number). If there is no associated issue, write "N/A".

ref: #390 

## Summary

- Focusing on 1st bullet point (Change them to take parameters, like `rerank_qwen_async` and `rerank_qwen_local`) of issue 390, linked above
- For `rerank_nvidia_openrouter.py` and `rerank_qwen_openrouter.py`, removed separate thinking & non-thinking demos, replaced by adding custom argument for thinking mode
- For demos using `bright` collection, removed the for loop that includes all subdomains, replaced by adding custom argument for subcategories
- `rerank_openrouter.py`, `rerank_nvidia_openrouter.py`,  `rerank_qwen_openrouter.py` could not be tested as their free endpoints are now unavailable through OpenRouter
- Parameterized the below demos: (8 total)
  - `rerank_qwen.py`
    - Passed, successfully executed, 1:1 (reasonable difference) results reproduced
  - `rerank_qwen-r1-distill.py`
    - Passed, successfully executed
  - `rerank_openrouter.py`
    - stale endpoint
    - see below
  - `rerank_nvidia_openrouter.py`
    - stale endpoint
    - "Error code: 404 - {'error': {'message': 'No endpoints found for nvidia/nemotron-nano-9b-v2:free.', 'code': 404}}"
  - `rerank_qwen_openrouter.py`
    - stale endpoint
    - "Error code: 404 - {'error': {'message': 'No endpoints found for deepseek/deepseek-r1-distill-qwen-14b:free.', 'code': 404}}"
  - `rerank_oss_bright.py`
    - unabled to be tested yet
  - `rerank_oss_bright_async.py`
    - unabled to be tested yet
  - `rerank_qwen3_bright.py`
    - unabled to be tested yet

## Why

This PR is aiming to reducing the amount of manual & expensive demos, by replacing hardcoded run specifications with optional arguments in argparse. 

## Validation

List the exact commands you ran, for example:

```bash
uv run pre-commit run --all-files
uv run python -m unittest discover test
```
```bash
.venv/bin/ruff check src/rank_llm/demo/rerank_qwen.py
.venv/bin/ruff format src/rank_llm/demo/rerank_qwen.py

# switched diff params
python src/rank_llm/demo/rerank_qwen.py \
  --dataset dl19 \
  --model Qwen/Qwen2.5-0.5B-Instruct \
  --num-queries 5 \
  --k 20 \
  --batch-size 4 \
  --context-size 4096 \
  --num-gpus 1 \
  --output-dir demo_outputs/qwen-smoke \
  --sampling-json '{"temperature":0.0,"seed":42}' \
  --skip-eval

# using defaults -> same reproduction results as hardcoded vers
python src/rank_llm/demo/rerank_qwen.py 

# above cmds were ran on all other edited files as well
```

## Follow-ups

1. `rerank_qwen_local` only passes in 1 option in its kwargs and does not include k and rerank_batch uses its default value (100). hence when —k=200 is specified in the demo, the reranker still only reranks first 100 results
2. `rerank_openrouter` actually uses the minimax-m2 model but just uses openrouter as its middle layer, so I think it would be clearer to rename file to `rerank_minimax_openrouter` to match with other files such as `rerank_nvidia_openrouter` 
3. No `sampling_kwargs` support for openrouter-related rerank demos as it uses `SafeOpenai` class, could be implemented?
4. Consider removing / swapping current stale OpenRouter endpoints to other supported versions that have free API calls?

If I get the green light for these, I’ll implement them!

## Checklist Items

Before submitting your pull request, please review these items:

- [x] Have you followed the [contributing guidelines](CONTRIBUTING.md)?
- [x] Have you verified that there are no existing [Pull Requests](https://github.com/castorini/rank_llm/pulls) for the same update/change?
- [x] Have you updated any relevant documentation or added new tests where needed?

# PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Reproduction logs
- [ ] Other... 
    - Description: 
